### PR TITLE
science generators fix

### DIFF
--- a/FNPlugin/Science/FNSeismicProbe.cs
+++ b/FNPlugin/Science/FNSeismicProbe.cs
@@ -86,35 +86,34 @@ namespace FNPlugin
                         science_vess_ref = probe_data.name;
                         bool transmitted = false;
                         string vessel_name = "";
-                        float science_amount = 0;
-                        int exp_number = 1;
+						float distribution_factor = 0;
 
-                        if (probe_data.HasValue("transmitted"))
+						if (probe_data.HasValue("transmitted"))
                             transmitted = bool.Parse(probe_data.GetValue("transmitted"));
                         if (probe_data.HasValue("vesselname"))
                             vessel_name = probe_data.GetValue("vesselname");
-                        if (probe_data.HasValue("science"))
-                            science_amount = float.Parse(probe_data.GetValue("science"));
-                        if (probe_data.HasValue("number"))
-                            exp_number = int.Parse(probe_data.GetValue("number"));
-
+						if (probe_data.HasValue("distribution_factor"))
+							distribution_factor = float.Parse(probe_data.GetValue("distribution_factor"));
+						
                         if (!transmitted)
                         {
                             ScienceSubject subject = ResearchAndDevelopment.GetExperimentSubject(experiment, ExperimentSituations.SrfLanded, vessel.mainBody, vessel.mainBody.name + "'s surface.");
                             if (subject == null)
-                            {
                                 return false;
-                            }
-                            result_string = vessel_name + " impacted into " + vessel.mainBody.name + " producing seismic activity.  From this data, information on the structure of " + vessel.mainBody.name + "'s crust can be determined.";
-                            transmit_value = science_amount;
-                            recovery_value = science_amount;
-                            subject.subjectValue = 1;
-                            subject.scientificValue = 1;
-                            subject.scienceCap = 50 * 10 * PluginHelper.getScienceMultiplier(vessel);  //PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.flightGlobalsIndex);
-                            //subject.science = 0;
-                            data_size = science_amount * 2.5f;
-                            science_data = new ScienceData(science_amount, 1, 0, subject.id, "Impactor Data");
-                            ref_value = 50 * PluginHelper.getScienceMultiplier(vessel); // PluginHelper.getImpactorScienceMultiplier(vessel.mainBody.flightGlobalsIndex);
+							subject.subjectValue = PluginHelper.getScienceMultiplier(vessel);
+							subject.scienceCap = 10 * experiment.baseValue * subject.subjectValue;
+
+							float base_science = experiment.baseValue * distribution_factor;
+							data_size = base_science * subject.dataScale;
+							science_data = new ScienceData((float)data_size, 1f, 0f, subject.id, "Impactor Data");
+
+							result_string = vessel_name + " impacted into " + vessel.mainBody.name + " producing seismic activity.  From this data, information on the structure of " + vessel.mainBody.name + "'s crust can be determined.";
+
+							float science_amount = base_science * subject.subjectValue;
+							recovery_value = science_amount * subject.scientificValue;
+							transmit_value = recovery_value;
+							ref_value = subject.scienceCap;
+
                             return true;
                         }
                     }
@@ -172,8 +171,6 @@ namespace FNPlugin
                 }
                 config.Save(PluginHelper.PluginSaveFilePath);
             }
-
         }
-
     }
 }

--- a/FNPlugin/Science/ModableExperimentResultDialogPage.cs
+++ b/FNPlugin/Science/ModableExperimentResultDialogPage.cs
@@ -19,16 +19,18 @@ namespace FNPlugin
 
         public void setUpScienceData(string experiment_title, string experiment_results, float transmitValue, float recoveryValue, float data_size, float xmitScalar, float refValue)
         {
-            this.title = experiment_title;
+			this.title = experiment_title;
             this.resultText = experiment_results;
             //this.transmitValue = valueAfterTransmit;
-            this.valueAfterTransmit = transmitValue;
-            this.valueAfterRecovery = recoveryValue;
-            this.dataSize = data_size;
-            this.xmitDataScalar = xmitScalar;
-            this.refValue = transmitValue;
-            this.scienceValue = recoveryValue;
-            this.baseTransmitValue = transmitValue;
+
+			// No need for manual tinkering now
+            //this.valueAfterTransmit = transmitValue;
+            //this.valueAfterRecovery = recoveryValue;
+            //this.dataSize = data_size;
+            //this.xmitDataScalar = xmitScalar;
+            //this.refValue = refValue;
+            //this.scienceValue = recoveryValue;
+            //this.baseTransmitValue = transmitValue;
         }
     }
 }

--- a/FNPlugin/Science/ModuleModableScienceGenerator.cs
+++ b/FNPlugin/Science/ModuleModableScienceGenerator.cs
@@ -79,27 +79,25 @@ namespace FNPlugin
         {
             if (science_data != null)
             {
-                if (merdp == null || !data_gend)
-                {
-                    ExperimentsResultDialog.DisplayResult(merdp = new ModableExperimentResultDialogPage(
-                            base.part,
-                            this.science_data,
-                            this.science_data.baseTransmitValue,
-                            0,
-                            false,
-                            "",
-                            true,
-                            false,
-                            new Callback<ScienceData>(this.endExperiment),
-                            new Callback<ScienceData>(this.keepData),
-                            new Callback<ScienceData>(this.sendDataToComms),
-                            new Callback<ScienceData>(this.sendDataToLab)));
-
-                    merdp.setUpScienceData(result_title, result_string, (float)transmit_value, (float)recovery_value, (float)data_size, xmit_scalar, ref_value);
-                }
-                else
-                    ExperimentsResultDialog.DisplayResult(merdp);
-            }
+				if (merdp == null || !data_gend)
+				{
+					merdp = new ModableExperimentResultDialogPage(
+							base.part,
+							this.science_data,
+							this.science_data.baseTransmitValue,
+							0,
+							false,
+							"",
+							true,
+							false,
+							new Callback<ScienceData>(this.endExperiment),
+							new Callback<ScienceData>(this.keepData),
+							new Callback<ScienceData>(this.sendDataToComms),
+							new Callback<ScienceData>(this.sendDataToLab));
+					merdp.setUpScienceData(result_title, result_string, (float)transmit_value, (float)recovery_value, (float)data_size, xmit_scalar, ref_value);
+				}
+				ExperimentsResultDialog.DisplayResult(merdp);
+			}
             else
                 ResetExperiment();
         }
@@ -180,8 +178,8 @@ namespace FNPlugin
             {
                 this.science_data = null;
                 merdp = null;
-                result_string = null;
-                result_title = null;
+                result_string = ""; // null causes error in save process
+                result_title = ""; // null causes error in save proccess
                 transmit_value = 0;
                 recovery_value = 0;
                 Deployed = false;


### PR DESCRIPTION
* Changed impact science so that the distribution factor (multiplier)
for the seismic detectors, not the amount of science, is recorded in
WarpPlugin.cfg. In this way mistakes in setting up the seismic
detectors will no longer limit the total amount of science available
for that impact experiment.

* Fixed the experiment result dialog boxes so that they show
appropriate results.

* Fixed science rate display of the telescope, the science lab and the
AI computer core.