### PR TITLE
Added a new solar wind process to the refinery

### DIFF
--- a/FNPlugin/InterstellarResourcesConfiguration.cs
+++ b/FNPlugin/InterstellarResourcesConfiguration.cs
@@ -46,6 +46,7 @@ namespace FNPlugin
         private String _water = "Water";
         private String _heavyWater = "HeavyWater";
         private String _tritium = "LqdTritium";
+        private String _solarWind = "SolarWind"; 
 
         public String Actinides { get { return _ACTINIDES; } }
         public String Alumina { get { return _ALUMINA; } }
@@ -74,6 +75,7 @@ namespace FNPlugin
         public String Nitrogen { get { return _nitrogen; } }
         public String Oxygen { get { return _oxygen; } }
         public String Plutonium238 { get { return _PLUTONIUM_238; } }
+        public String SolarWind { get { return _solarWind; } }
         public String ThoriumTetraflouride { get { return _THORIUM_TETRAFLOURIDE; } }
         public String LqdTritium { get { return _tritium; } }
         public String UraniumTetraflouride { get { return _uranium_TerraFloride; } }
@@ -152,7 +154,11 @@ namespace FNPlugin
                     _oxygen = plugin_settings.GetValue("OxygenResourceName");
                     Debug.Log("[KSP Interstellar] Oxygen resource name set to " + Oxygen);
                 }
-
+                if (plugin_settings.HasValue("SolarWindResourceName"))
+                {
+                    _solarWind = plugin_settings.GetValue("SolarWindResourceName");
+                    Debug.Log("[KSP Interstellar] SolarWind resource name set to " + _solarWind);
+                }
                 if (plugin_settings.HasValue("TritiumResourceName"))
                 {
                     _tritium = plugin_settings.GetValue("TritiumResourceName");

--- a/FNPlugin/Refinery/InterstellarRefinery.cs
+++ b/FNPlugin/Refinery/InterstellarRefinery.cs
@@ -76,6 +76,7 @@ namespace FNPlugin.Refinery
                 unsortedList.Add(new WaterGasShift(this.part));
                 unsortedList.Add(new ReverseWaterGasShift(this.part));
                 unsortedList.Add(new MethanePyrolyser(this.part));
+                unsortedList.Add(new SolarWindProcessor(this.part));
             }
             catch (Exception e)
             {

--- a/FNPlugin/Refinery/ReverseWaterGasShift.cs
+++ b/FNPlugin/Refinery/ReverseWaterGasShift.cs
@@ -221,7 +221,7 @@ namespace FNPlugin.Refinery
         private void updateStatusMessage()
         {
             if (_monoxide_production_rate > 0 && _water_production_rate > 0)
-                _status = "Water Gas Swifting";
+                _status = "Water Gas Shifting";
             else if (_fixedConsumptionRate <= 0.0000000001)
             {
                 if (_availableDioxideMass <= 0.0000000001)

--- a/FNPlugin/Refinery/SolarWindProcessor.cs
+++ b/FNPlugin/Refinery/SolarWindProcessor.cs
@@ -1,0 +1,279 @@
+﻿using OpenResourceSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace FNPlugin.Refinery
+{
+    class SolarWindProcessor : IRefineryActivity
+    {
+        const int labelWidth = 200;
+        const int valueWidth = 200;
+
+        protected Part _part;
+        protected Vessel _vessel;
+        protected String _status = "";
+        protected double _current_power;
+        protected double _fixedConsumptionRate;
+        protected double _consumptionStorageRatio;
+
+        protected double _solar_wind_density;
+        protected double _hydrogen_density;
+        protected double _liquid_helium3_density;
+        protected double _liquid_helium4_density;
+        protected double _monoxide_density;
+        protected double _nitrogen_density;
+
+        protected double _solar_wind_consumption_rate;
+
+        protected double _hydrogen_production_rate;
+        protected double _liquid_helium3_production_rate;
+        protected double _liquid_helium4_production_rate;
+        protected double _monoxide_production_rate;
+        protected double _nitrogen_production_rate;
+        protected double _current_rate;
+
+
+        private GUIStyle _bold_label;
+
+        public String ActivityName { get { return "Solar Wind Process"; } }
+
+        public double CurrentPower { get { return _current_power; } }
+
+        public bool HasActivityRequirements {
+            get
+            {
+                return _part.GetConnectedResources(_solar_wind_resource_name).Any(rs => rs.amount > 0);
+            }
+        }
+
+        public double PowerRequirements { get { return PluginHelper.BaseELCPowerConsumption; } }
+
+        public String Status { get { return String.Copy(_status); } }
+
+        protected string _solar_wind_resource_name;
+        protected string _hydrogen_resource_name;
+        protected string _liquid_helium3_resource_name;
+        protected string _liquid_helium4_resource_name;
+        protected string _monoxide_resource_name;
+        protected string _nitrogen_resource_name;
+
+        public SolarWindProcessor(Part part)
+        {
+            _part = part;
+            _vessel = part.vessel;
+
+            _solar_wind_resource_name = InterstellarResourcesConfiguration.Instance.SolarWind;
+            _hydrogen_resource_name = InterstellarResourcesConfiguration.Instance.Hydrogen;
+            _liquid_helium3_resource_name = InterstellarResourcesConfiguration.Instance.LqdHelium3;
+            _liquid_helium4_resource_name = InterstellarResourcesConfiguration.Instance.LqdHelium4;
+            _monoxide_resource_name = InterstellarResourcesConfiguration.Instance.CarbonMoxoxide;
+            _nitrogen_resource_name = InterstellarResourcesConfiguration.Instance.Nitrogen;
+
+            _solar_wind_density = PartResourceLibrary.Instance.GetDefinition(_solar_wind_resource_name).density;
+            _hydrogen_density = PartResourceLibrary.Instance.GetDefinition(_hydrogen_resource_name).density;
+            _liquid_helium3_density = PartResourceLibrary.Instance.GetDefinition(_liquid_helium3_resource_name).density;
+            _liquid_helium4_density = PartResourceLibrary.Instance.GetDefinition(_liquid_helium4_resource_name).density;
+            _monoxide_density = PartResourceLibrary.Instance.GetDefinition(_monoxide_resource_name).density;
+            _nitrogen_density = PartResourceLibrary.Instance.GetDefinition(_nitrogen_resource_name).density;
+        }
+
+        protected double _maxCapacitySolarWindMass;
+        protected double _maxCapacityHydrogenMass;
+        protected double _maxCapacityHelium3Mass;
+        protected double _maxCapacityHelium4Mass;
+        protected double _maxCapacityMonoxideMass;
+        protected double _maxCapacityNitrogenMass;
+
+        protected double _availableSolarWindMass;
+        protected double _spareRoomHydrogenMass;
+        protected double _spareRoomHelium3Mass;
+        protected double _spareRoomHelium4Mass;
+        protected double _spareRoomMonoxideMass;
+        protected double _spareRoomNitrogenMass;
+
+        /* these are the constituents of solar wind with their appropriate mass ratios. According to http://solar-center.stanford.edu/FAQ/Qsolwindcomp.html and other sources,
+         * about 90 % of atoms in solar wind are hydrogen. About 8 % is helium (he-3 is less stable than he-4 so i guesstimated that about quarter of those 8 % could be he-3,
+         * so I take that 2 % of atoms in solar wind are he-3 and 6 % of atoms in solar wind are the more stable he-4). There are supposedly only trace amounts of heavier elements such as C, N and O,
+         * so I decided on 1 % of atoms for both CO and N. The exact fractions were calculated as (percentage * atomic mass of the element) / Sum of (percentage * atomic mass of the element) for every element.
+        */
+        protected double _hydrogenMassByFraction = 0.1118; // see above how I got this number (as an example 0.9 * 1.008 / 8.1133 = 0.1118), ie. percentage times atomic mass of He-3 / sum of the same stuff in numerator for every element
+        protected double _helium3MassByFraction = 0.0743; // because examples are nice to have (0.2 * 3.016 / 8.1133 = 0.0743)
+        protected double _helium4MassByFraction = 0.2959;
+        protected double _monoxideMassByFraction = 0.3452;
+        protected double _nitrogenMassByFraction = 0.1726;
+
+
+        public void UpdateFrame(double rateMultiplier, bool allowOverflow)
+        {
+            _current_power = PowerRequirements * rateMultiplier;
+            _current_rate = CurrentPower / PluginHelper.ElectrolysisEnergyPerTon;
+
+            // determine how much resource we have
+            var partsThatContainSolarWind = _part.GetConnectedResources(_solar_wind_resource_name);
+            var partsThatContainHydrogen = _part.GetConnectedResources(_hydrogen_resource_name);
+            var partsThatContainLqdHelium3 = _part.GetConnectedResources(_liquid_helium3_resource_name);
+            var partsThatContainLqdHelium4 = _part.GetConnectedResources(_liquid_helium4_resource_name);
+            var partsThatContainMonoxide = _part.GetConnectedResources(_monoxide_resource_name);
+            var partsThatContainNitrogen = _part.GetConnectedResources(_nitrogen_resource_name);
+
+            // determine the maximum amount of a resource the vessel can hold (ie. tank capacities combined)
+            _maxCapacitySolarWindMass = partsThatContainSolarWind.Sum(p => p.maxAmount) * _solar_wind_density;
+            _maxCapacityHydrogenMass = partsThatContainHydrogen.Sum(p => p.maxAmount) * _hydrogen_density;
+            _maxCapacityHelium3Mass = partsThatContainLqdHelium3.Sum(p => p.maxAmount) * _liquid_helium3_density;
+            _maxCapacityHelium4Mass = partsThatContainLqdHelium4.Sum(p => p.maxAmount) * _liquid_helium4_density;
+            _maxCapacityMonoxideMass = partsThatContainMonoxide.Sum(p => p.maxAmount) * _monoxide_density;
+            _maxCapacityNitrogenMass = partsThatContainNitrogen.Sum(p => p.maxAmount) * _nitrogen_density;
+
+            // determine the amount of resources needed for processing (i.e. solar wind) that the vessel actually holds
+            _availableSolarWindMass = partsThatContainSolarWind.Sum(r => r.amount) * _solar_wind_density;
+
+            // determine how much spare room there is in the vessel's resource tanks (for the resources this is going to produce)
+            _spareRoomHydrogenMass = partsThatContainHydrogen.Sum(r => r.maxAmount - r.amount) * _hydrogen_density;
+            _spareRoomHelium3Mass = partsThatContainLqdHelium3.Sum(r => r.maxAmount - r.amount) * _liquid_helium3_density;
+            _spareRoomHelium4Mass = partsThatContainLqdHelium4.Sum(r => r.maxAmount - r.amount) * _liquid_helium4_density;
+            _spareRoomMonoxideMass = partsThatContainMonoxide.Sum(r => r.maxAmount - r.amount) * _monoxide_density;
+            _spareRoomNitrogenMass = partsThatContainNitrogen.Sum(r => r.maxAmount - r.amount) * _nitrogen_density;
+
+            // this should determine how much resource this process can consume
+            var fixedMaxSolarWindConsumptionRate = _current_rate * TimeWarp.fixedDeltaTime * _solar_wind_density;
+            var solarWindConsumptionRatio = fixedMaxSolarWindConsumptionRate > 0
+                ? Math.Min(fixedMaxSolarWindConsumptionRate, _availableSolarWindMass) / fixedMaxSolarWindConsumptionRate
+                : 0;
+
+            _fixedConsumptionRate = _current_rate * TimeWarp.fixedDeltaTime * solarWindConsumptionRatio;
+
+            // begin the solar wind processing
+            if (_fixedConsumptionRate > 0 && ((((_spareRoomHydrogenMass > 0 || _spareRoomHelium3Mass > 0) || _spareRoomHelium4Mass > 0) || _spareRoomMonoxideMass > 0) || _spareRoomNitrogenMass > 0)) // check if there is anything to consume and spare room for at least one of the products
+            {
+                
+                var fixedMaxHydrogenRate = _fixedConsumptionRate * _hydrogenMassByFraction;
+                var fixedMaxHelium3Rate = _fixedConsumptionRate * _helium3MassByFraction;
+                var fixedMaxHelium4Rate = _fixedConsumptionRate * _helium4MassByFraction;
+                var fixedMaxMonoxideRate = _fixedConsumptionRate * _monoxideMassByFraction;
+                var fixedMaxNitrogenRate = _fixedConsumptionRate * _nitrogenMassByFraction;
+
+                var fixedMaxPossibleHydrogenRate = allowOverflow ? fixedMaxHydrogenRate : Math.Min(_spareRoomHydrogenMass, fixedMaxHydrogenRate);
+                var fixedMaxPossibleHelium3Rate = allowOverflow ? fixedMaxHelium3Rate : Math.Min(_spareRoomHelium3Mass, fixedMaxHelium3Rate);
+                var fixedMaxPossibleHelium4Rate = allowOverflow ? fixedMaxHelium4Rate : Math.Min(_spareRoomHelium4Mass, fixedMaxHelium4Rate);
+                var fixedMaxPossibleMonoxideRate = allowOverflow ? fixedMaxMonoxideRate : Math.Min(_spareRoomMonoxideMass, fixedMaxMonoxideRate);
+                var fixedMaxPossibleNitrogenRate = allowOverflow ? fixedMaxNitrogenRate : Math.Min(_spareRoomNitrogenMass, fixedMaxNitrogenRate);
+
+                // finds the minimum of these five numbers (fixedMaxPossibleZZRate / fixedMaxZZRate), adapted from water electrolyser. Could be more pretty with a custom Min5() function, but eh.
+                _consumptionStorageRatio = Math.Min(Math.Min(Math.Min(Math.Min(fixedMaxPossibleHydrogenRate / fixedMaxHydrogenRate, fixedMaxPossibleHelium3Rate / fixedMaxHelium3Rate), fixedMaxPossibleHelium4Rate / fixedMaxHelium4Rate), fixedMaxPossibleMonoxideRate / fixedMaxMonoxideRate), fixedMaxPossibleNitrogenRate / fixedMaxNitrogenRate);
+                               
+                // this consumes the resource
+                _solar_wind_consumption_rate = _part.RequestResource(_solar_wind_resource_name, _consumptionStorageRatio * _fixedConsumptionRate / _solar_wind_density) / TimeWarp.fixedDeltaTime * _solar_wind_density;
+
+                // this produces the products
+                var hydrogen_rate_temp = _solar_wind_consumption_rate * _hydrogenMassByFraction;
+                var helium3_rate_temp = _solar_wind_consumption_rate * _helium3MassByFraction;
+                var helium4_rate_temp = _solar_wind_consumption_rate * _helium4MassByFraction;
+                var monoxide_rate_temp = _solar_wind_consumption_rate * _monoxideMassByFraction;
+                var nitrogen_rate_temp = _solar_wind_consumption_rate * _nitrogenMassByFraction;
+
+                _hydrogen_production_rate = -_part.RequestResource(_hydrogen_resource_name, -hydrogen_rate_temp * TimeWarp.fixedDeltaTime / _hydrogen_density) / TimeWarp.fixedDeltaTime * _hydrogen_density;
+                _liquid_helium3_production_rate = -_part.RequestResource(_liquid_helium3_resource_name, -helium3_rate_temp * TimeWarp.fixedDeltaTime / _liquid_helium3_density) / TimeWarp.fixedDeltaTime * _liquid_helium3_density;
+                _liquid_helium4_production_rate = -_part.RequestResource(_liquid_helium4_resource_name, -helium4_rate_temp * TimeWarp.fixedDeltaTime / _liquid_helium4_density) / TimeWarp.fixedDeltaTime * _liquid_helium4_density;
+                _monoxide_production_rate = -_part.RequestResource(_monoxide_resource_name, -monoxide_rate_temp * TimeWarp.fixedDeltaTime / _monoxide_density) / TimeWarp.fixedDeltaTime * _monoxide_density;
+                _nitrogen_production_rate = -_part.RequestResource(_nitrogen_resource_name, -nitrogen_rate_temp * TimeWarp.fixedDeltaTime / _nitrogen_density) / TimeWarp.fixedDeltaTime * _nitrogen_density;
+            }
+            else
+            {
+                _solar_wind_consumption_rate = 0;
+                _hydrogen_production_rate = 0;
+                _liquid_helium3_production_rate = 0;
+                _liquid_helium3_production_rate = 0;
+                _monoxide_production_rate = 0;
+                _nitrogen_production_rate = 0;
+            }
+            updateStatusMessage();
+        }
+
+        public void UpdateGUI()
+        {
+            if (_bold_label == null)
+            {
+                _bold_label = new GUIStyle(GUI.skin.label);
+                _bold_label.fontStyle = FontStyle.Bold;
+            }
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Power", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(PluginHelper.getFormattedPowerString(CurrentPower) + "/" + PluginHelper.getFormattedPowerString(PowerRequirements), GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Solar Wind Consumption", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(((_solar_wind_consumption_rate / TimeWarp.fixedDeltaTime * GameConstants.HOUR_SECONDS).ToString("0.0000")) + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Solar Wind Available", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_availableSolarWindMass.ToString("0.0000") + " mT / " + _maxCapacitySolarWindMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Hydrogen Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_spareRoomHydrogenMass.ToString("0.0000") + " mT / " + _maxCapacityHydrogenMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Hydrogen Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((_hydrogen_production_rate * GameConstants.HOUR_SECONDS).ToString("0.000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-3 Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_spareRoomHelium3Mass.ToString("0.0000") + " mT / " + _maxCapacityHelium3Mass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-3 Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((_liquid_helium3_production_rate * GameConstants.HOUR_SECONDS).ToString("0.000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-4 Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_spareRoomHelium4Mass.ToString("0.0000") + " mT / " + _maxCapacityHelium4Mass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-4 Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((_liquid_helium4_production_rate * GameConstants.HOUR_SECONDS).ToString("0.000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Monoxide Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_spareRoomMonoxideMass.ToString("0.0000") + " mT / " + _maxCapacityMonoxideMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Monoxide Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((_monoxide_production_rate * GameConstants.HOUR_SECONDS).ToString("0.000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Nitrogen Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(_spareRoomNitrogenMass.ToString("0.0000") + " mT / " + _maxCapacityNitrogenMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Nitrogen Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((_nitrogen_production_rate * GameConstants.HOUR_SECONDS).ToString("0.000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+        }
+
+        private void updateStatusMessage()
+        {
+            if (_solar_wind_consumption_rate > 0)
+                _status = "Processing of Solar Wind Particles Ongoing";
+            else if (CurrentPower <= 0.01*PowerRequirements)
+                _status = "Insufficient Power";
+            else
+                _status = "Insufficient Storage, try allowing overflow";
+        }
+    }
+}

--- a/FNPlugin/WarpPlugin.csproj
+++ b/FNPlugin/WarpPlugin.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Propulsion\VistaEngineControllerAdvanced2.cs" />
     <Compile Include="Refinery\AluminiumElectrolyser.cs" />
     <Compile Include="Collectors\AntimatterCollector.cs" />
+    <Compile Include="Refinery\SolarWindProcessor.cs" />
     <Compile Include="Refinery\AntimatterFactory.cs" />
     <Compile Include="Collectors\AtmosphericIntake.cs" />
     <Compile Include="Refinery\AnthraquinoneProcessor.cs" />

--- a/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
@@ -164,6 +164,13 @@ bulkheadProfiles = size2, size3, srf
         	maxAmount = 10
     	}
 
+        RESOURCE
+    	{
+        	name = SolarWind
+        	amount = 0
+        	maxAmount = 10
+    	}
+
 	MODULE
 	{
 		name = ModuleResourceConverter
@@ -412,99 +419,7 @@ bulkheadProfiles = size2, size3, srf
 		}
 	}
 
-	MODULE
-	{
-		name = ModuleResourceConverter
-		ConverterName = SolarWind Processor
-		StartActionName = Start SolarWind Processing
-		StopActionName = Stop SolarWind Processing
-		AutoShutdown = true
-		TemperatureModifier
-		{
-			key = 0 100000
-			key = 750 50000
-			key = 1000 10000
-			key = 1250 500	
-			key = 2000 50	
-			key = 4000 0
-		}				
-		GeneratesHeat = true
-		DefaultShutoffTemp = .8
-		ThermalEfficiency 
-		{
-			key = 0 0 0 0
-			key = 500 0.1 0 0
-			key = 1000 1.0 0 0
-			key = 1250 0.1 0 0
-			key = 3000 0 0 0 
-		}
-
-		UseSpecialistBonus = true
-		SpecialistEfficiencyFactor = 0.2
-		SpecialistBonusBase = 0.05
-		Specialty = Engineer
-		EfficiencyBonus = 1
-
-		INPUT_RESOURCE
-		{
-			ResourceName = SolarWind
-			Ratio = 10
-		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ElectricCharge
-			Ratio = 18
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = LqdHydrogen
-			Ratio = 0.095
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Helium4
-			Ratio = 0.4
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Helium3
-			Ratio = 0.001
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = LqdNitrogen
-			Ratio = 0.01
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = LqdOxygen
-			Ratio = 0.01
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = Carbon
-			Ratio = 0.01
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = ArgonGas
-			Ratio = 0.001
-			DumpExcess = True
-		}
-		OUTPUT_RESOURCE
-		{
-			ResourceName = NeonGas
-			Ratio = 0.001
-			DumpExcess = True
-		}
-	}
-
+	
 	MODULE
 	{
 		name = ModuleResourceConverter


### PR DESCRIPTION
Added a new process to the refinery for processing solar wind into its constituents (H, He-3, He-4, CO, N). Removed a similar module-based process from ISRU part config. Added a new resource capacity to the ISRU part, it can now also hold 10 units of solar wind resource. Fixed a typo in one of ReverseWaterGasShift GUI labels.