### PR TITLE
Regolith

### DIFF
--- a/FNPlugin/InterstellarResourcesConfiguration.cs
+++ b/FNPlugin/InterstellarResourcesConfiguration.cs
@@ -47,7 +47,8 @@ namespace FNPlugin
         private String _heavyWater = "HeavyWater";
         private String _tritium = "LqdTritium";
         private String _solarWind = "SolarWind";
-        private String _neon_gas = "NeonGas"; 
+        private String _neon_gas = "NeonGas";
+        private String _regolith = "Regolith";
 
         public String Actinides { get { return _ACTINIDES; } }
         public String Alumina { get { return _ALUMINA; } }
@@ -77,6 +78,7 @@ namespace FNPlugin
         public String Nitrogen { get { return _nitrogen; } }
         public String Oxygen { get { return _oxygen; } }
         public String Plutonium238 { get { return _PLUTONIUM_238; } }
+        public String Regolith { get { return _regolith; } }
         public String SolarWind { get { return _solarWind; } }
         public String ThoriumTetraflouride { get { return _THORIUM_TETRAFLOURIDE; } }
         public String LqdTritium { get { return _tritium; } }
@@ -170,10 +172,15 @@ namespace FNPlugin
                     _oxygen = plugin_settings.GetValue("OxygenResourceName");
                     Debug.Log("[KSP Interstellar] Oxygen resource name set to " + Oxygen);
                 }
+                if (plugin_settings.HasValue("RegolithResourceName"))
+                {
+                    _regolith = plugin_settings.GetValue("RegolithResourceName");
+                    Debug.Log("[KSP Interstellar] Regolith resource name set to " + Regolith);
+                }
                 if (plugin_settings.HasValue("SolarWindResourceName"))
                 {
                     _solarWind = plugin_settings.GetValue("SolarWindResourceName");
-                    Debug.Log("[KSP Interstellar] SolarWind resource name set to " + _solarWind);
+                    Debug.Log("[KSP Interstellar] SolarWind resource name set to " + SolarWind);
                 }
                 if (plugin_settings.HasValue("TritiumResourceName"))
                 {

--- a/FNPlugin/Refinery/InterstellarRefinery.cs
+++ b/FNPlugin/Refinery/InterstellarRefinery.cs
@@ -37,7 +37,7 @@ namespace FNPlugin.Refinery
 
         private List<IRefineryActivity> _refinery_activities;
         private IRefineryActivity _current_activity = null;
-        private Rect _window_position = new Rect(50, 50, labelWidth + valueWidth, 100);
+        private Rect _window_position = new Rect(50, 50, labelWidth + valueWidth, 150);
         private int _window_ID;
         private bool _render_window;
 
@@ -77,6 +77,8 @@ namespace FNPlugin.Refinery
                 unsortedList.Add(new ReverseWaterGasShift(this.part));
                 unsortedList.Add(new MethanePyrolyser(this.part));
                 unsortedList.Add(new SolarWindProcessor(this.part));
+                unsortedList.Add(new RegolithProcessor(this.part));
+
             }
             catch (Exception e)
             {

--- a/FNPlugin/Refinery/RegolithProcessor.cs
+++ b/FNPlugin/Refinery/RegolithProcessor.cs
@@ -1,0 +1,357 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OpenResourceSystem;
+using UnityEngine;
+
+namespace FNPlugin.Refinery
+{
+    class RegolithProcessor : IRefineryActivity
+    {
+        const int labelWidth = 200;
+        const int valueWidth = 200;
+
+        protected Part _part;
+        protected Vessel _vessel;
+        protected String _status = "";
+        protected double _currentPower;
+        protected double dFixedConsumptionRate;
+        protected double dConsumptionStorageRatio;
+
+        protected double dRegolithDensity;
+        protected double dHydrogenDensity;
+        protected double dLiquidHelium3Density;
+        protected double dLiquidHelium4Density;
+        protected double dMonoxideDensity;
+        protected double dDioxideDensity;
+        protected double dMethaneDensity;
+        protected double dNitrogenDensity;
+        protected double dWaterDensity;
+
+        protected double dRegolithConsumptionRate;
+
+        protected double dHydrogenProductionRate;
+        protected double dLiquidHelium3ProductionRate;
+        protected double dLiquidHelium4ProductionRate;
+        protected double dMonoxideProductionRate;
+        protected double dDioxideProductionRate;
+        protected double dMethaneProductionRate;
+        protected double dNitrogenProductionRate;
+        protected double dWaterProductionRate;
+        protected double dCurrentRate;
+
+
+        private GUIStyle _bold_label;
+
+        public String ActivityName { get { return "Regolith Process"; } }
+
+        public double CurrentPower { get { return _currentPower; } }
+
+        public bool HasActivityRequirements
+        {
+            get
+            {
+                return _part.GetConnectedResources(strRegolithResourceName).Any(rs => rs.amount > 0);
+            }
+        }
+
+        public double PowerRequirements { get { return PluginHelper.BaseELCPowerConsumption; } }
+
+        public String Status { get { return String.Copy(_status); } }
+
+        protected string strRegolithResourceName;
+        protected string strHydrogenResourceName;
+        protected string strLiquidHelium3ResourceName;
+        protected string strLiquidHelium4ResourceName;
+        protected string strMonoxideResourceName;
+        protected string strDioxideResourceName;
+        protected string strMethaneResourceName;
+        protected string strNitrogenResourceName;
+        protected string strWaterResourceName;
+
+        public RegolithProcessor(Part part)
+        {
+            _part = part;
+            _vessel = part.vessel;
+
+            strRegolithResourceName = InterstellarResourcesConfiguration.Instance.Regolith;
+            strHydrogenResourceName = InterstellarResourcesConfiguration.Instance.Hydrogen;
+            strLiquidHelium3ResourceName = InterstellarResourcesConfiguration.Instance.LqdHelium3;
+            strLiquidHelium4ResourceName = InterstellarResourcesConfiguration.Instance.LqdHelium4;
+            strMonoxideResourceName = InterstellarResourcesConfiguration.Instance.CarbonMoxoxide;
+            strDioxideResourceName = InterstellarResourcesConfiguration.Instance.CarbonDioxide;
+            strMethaneResourceName = InterstellarResourcesConfiguration.Instance.Methane;
+            strNitrogenResourceName = InterstellarResourcesConfiguration.Instance.Nitrogen;
+            strWaterResourceName = InterstellarResourcesConfiguration.Instance.Water;
+
+            dRegolithDensity = PartResourceLibrary.Instance.GetDefinition(strRegolithResourceName).density;
+            dHydrogenDensity = PartResourceLibrary.Instance.GetDefinition(strHydrogenResourceName).density;
+            dLiquidHelium3Density = PartResourceLibrary.Instance.GetDefinition(strLiquidHelium3ResourceName).density;
+            dLiquidHelium4Density = PartResourceLibrary.Instance.GetDefinition(strLiquidHelium4ResourceName).density;
+            dMonoxideDensity = PartResourceLibrary.Instance.GetDefinition(strMonoxideResourceName).density;
+            dDioxideDensity = PartResourceLibrary.Instance.GetDefinition(strDioxideResourceName).density;
+            dMethaneDensity = PartResourceLibrary.Instance.GetDefinition(strMethaneResourceName).density;
+            dNitrogenDensity = PartResourceLibrary.Instance.GetDefinition(strNitrogenResourceName).density;
+            dWaterDensity = PartResourceLibrary.Instance.GetDefinition(strWaterResourceName).density;
+        }
+
+        protected double dMaxCapacityRegolithMass;
+        protected double dMaxCapacityHydrogenMass;
+        protected double dMaxCapacityHelium3Mass;
+        protected double dMaxCapacityHelium4Mass;
+        protected double dMaxCapacityMonoxideMass;
+        protected double dMaxCapacityDioxideMass;
+        protected double dMaxCapacityMethaneMass;
+        protected double dMaxCapacityNitrogenMass;
+        protected double dMaxCapacityWaterMass;
+
+        protected double dAvailableRegolithMass;
+        protected double dSpareRoomHydrogenMass;
+        protected double dSpareRoomHelium3Mass;
+        protected double dSpareRoomHelium4Mass;
+        protected double dSpareRoomMonoxideMass;
+        protected double dSpareRoomDioxideMass;
+        protected double dSpareRoomMethaneMass;
+        protected double dSpareRoomNitrogenMass;
+        protected double dSpareRoomWaterMass;
+
+        /* these are the constituents of regolith with their appropriate mass ratios. I'm using concentrations from lunar regolith, yes, I know regolith on other planets varies, let's keep this simple.
+         * The exact fractions were calculated mostly from a chart that's also available on http://imgur.com/lpaE1Ah.
+         */
+        protected double dHydrogenMassByFraction = 0.3351464205;
+        protected double dHelium3MassByFraction = 0.000054942036;
+        protected double dHelium4MassByFraction = 0.1703203120;
+        protected double dMonoxideMassByFraction = 0.1043898686;
+        protected double dDioxideMassByFraction = 0.0934014614;
+        protected double dMethaneMassByFraction = 0.0879072578;
+        protected double dNitrogenMassByFraction = 0.0274710180;
+        protected double dWaterMassByFraction = 0.18130871930;
+
+
+        public void UpdateFrame(double rateMultiplier, bool allowOverflow)
+        {
+            _currentPower = PowerRequirements * rateMultiplier;
+            dCurrentRate = CurrentPower / PluginHelper.ElectrolysisEnergyPerTon;
+
+            // determine how much resource we have
+            var partsThatContainRegolith = _part.GetConnectedResources(strRegolithResourceName);
+            var partsThatContainHydrogen = _part.GetConnectedResources(strHydrogenResourceName);
+            var partsThatContainLqdHelium3 = _part.GetConnectedResources(strLiquidHelium3ResourceName);
+            var partsThatContainLqdHelium4 = _part.GetConnectedResources(strLiquidHelium4ResourceName);
+            var partsThatContainMonoxide = _part.GetConnectedResources(strMonoxideResourceName);
+            var partsThatContainDioxide = _part.GetConnectedResources(strDioxideResourceName);
+            var partsThatContainMethane = _part.GetConnectedResources(strMethaneResourceName);
+            var partsThatContainNitrogen = _part.GetConnectedResources(strNitrogenResourceName);
+            var partsThatContainWater = _part.GetConnectedResources(strWaterResourceName);
+
+            // determine the maximum amount of a resource the vessel can hold (ie. tank capacities combined)
+            dMaxCapacityRegolithMass = partsThatContainRegolith.Sum(p => p.maxAmount) * dRegolithDensity;
+            dMaxCapacityHydrogenMass = partsThatContainHydrogen.Sum(p => p.maxAmount) * dHydrogenDensity;
+            dMaxCapacityHelium3Mass = partsThatContainLqdHelium3.Sum(p => p.maxAmount) * dLiquidHelium3Density;
+            dMaxCapacityHelium4Mass = partsThatContainLqdHelium4.Sum(p => p.maxAmount) * dLiquidHelium4Density;
+            dMaxCapacityMonoxideMass = partsThatContainMonoxide.Sum(p => p.maxAmount) * dMonoxideDensity;
+            dMaxCapacityDioxideMass = partsThatContainDioxide.Sum(p => p.maxAmount) * dDioxideDensity;
+            dMaxCapacityMethaneMass = partsThatContainMethane.Sum(p => p.maxAmount) * dMethaneDensity;
+            dMaxCapacityNitrogenMass = partsThatContainNitrogen.Sum(p => p.maxAmount) * dNitrogenDensity;
+            dMaxCapacityWaterMass = partsThatContainWater.Sum(p => p.maxAmount) * dWaterDensity;
+
+            // determine the amount of resources needed for processing (i.e. regolith) that the vessel actually holds
+            dAvailableRegolithMass = partsThatContainRegolith.Sum(r => r.amount) * dRegolithDensity;
+
+            // determine how much spare room there is in the vessel's resource tanks (for the resources this is going to produce)
+            dSpareRoomHydrogenMass = partsThatContainHydrogen.Sum(r => r.maxAmount - r.amount) * dHydrogenDensity;
+            dSpareRoomHelium3Mass = partsThatContainLqdHelium3.Sum(r => r.maxAmount - r.amount) * dLiquidHelium3Density;
+            dSpareRoomHelium4Mass = partsThatContainLqdHelium4.Sum(r => r.maxAmount - r.amount) * dLiquidHelium4Density;
+            dSpareRoomMonoxideMass = partsThatContainMonoxide.Sum(r => r.maxAmount - r.amount) * dMonoxideDensity;
+            dSpareRoomDioxideMass = partsThatContainDioxide.Sum(r => r.maxAmount - r.amount) * dDioxideDensity;
+            dSpareRoomMethaneMass = partsThatContainMethane.Sum(r => r.maxAmount - r.amount) * dMethaneDensity;
+            dSpareRoomNitrogenMass = partsThatContainNitrogen.Sum(r => r.maxAmount - r.amount) * dNitrogenDensity;
+            dSpareRoomWaterMass = partsThatContainWater.Sum(r => r.maxAmount - r.amount) * dWaterDensity;
+
+            // this should determine how much resource this process can consume
+            double dFixedMaxRegolithConsumptionRate = dCurrentRate * TimeWarp.fixedDeltaTime * dRegolithDensity;
+            double dRegolithConsumptionRatio = dFixedMaxRegolithConsumptionRate > 0
+                ? Math.Min(dFixedMaxRegolithConsumptionRate, dAvailableRegolithMass) / dFixedMaxRegolithConsumptionRate
+                : 0;
+
+            dFixedConsumptionRate = dCurrentRate * TimeWarp.fixedDeltaTime * dRegolithConsumptionRatio;
+
+            // begin the regolith processing
+            if (dFixedConsumptionRate > 0 && ((((dSpareRoomHydrogenMass > 0 || dSpareRoomHelium3Mass > 0) || dSpareRoomHelium4Mass > 0) || dSpareRoomMonoxideMass > 0) || dSpareRoomNitrogenMass > 0)) // check if there is anything to consume and spare room for at least one of the products
+            {
+
+                double dFixedMaxHydrogenRate = dFixedConsumptionRate * dHydrogenMassByFraction;
+                double dFixedMaxHelium3Rate = dFixedConsumptionRate * dHelium3MassByFraction;
+                double dFixedMaxHelium4Rate = dFixedConsumptionRate * dHelium4MassByFraction;
+                double dFixedMaxMonoxideRate = dFixedConsumptionRate * dMonoxideMassByFraction;
+                double dFixedMaxDioxideRate = dFixedConsumptionRate * dDioxideMassByFraction;
+                double dFixedMaxMethaneRate = dFixedConsumptionRate * dMethaneMassByFraction;
+                double dFixedMaxNitrogenRate = dFixedConsumptionRate * dNitrogenMassByFraction;
+                double dFixedMaxWaterRate = dFixedConsumptionRate * dWaterMassByFraction;
+
+                double dFixedMaxPossibleHydrogenRate = allowOverflow ? dFixedMaxHydrogenRate : Math.Min(dSpareRoomHydrogenMass, dFixedMaxHydrogenRate);
+                double dFixedMaxPossibleHelium3Rate = allowOverflow ? dFixedMaxHelium3Rate : Math.Min(dSpareRoomHelium3Mass, dFixedMaxHelium3Rate);
+                double dFixedMaxPossibleHelium4Rate = allowOverflow ? dFixedMaxHelium4Rate : Math.Min(dSpareRoomHelium4Mass, dFixedMaxHelium4Rate);
+                double dFixedMaxPossibleMonoxideRate = allowOverflow ? dFixedMaxMonoxideRate : Math.Min(dSpareRoomMonoxideMass, dFixedMaxMonoxideRate);
+                double dFixedMaxPossibleDioxideRate = allowOverflow ? dFixedMaxDioxideRate : Math.Min(dSpareRoomDioxideMass, dFixedMaxDioxideRate);
+                double dFixedMaxPossibleMethaneRate = allowOverflow ? dFixedMaxMethaneRate : Math.Min(dSpareRoomMethaneMass, dFixedMaxMethaneRate);
+                double dFixedMaxPossibleNitrogenRate = allowOverflow ? dFixedMaxNitrogenRate : Math.Min(dSpareRoomNitrogenMass, dFixedMaxNitrogenRate);
+                double dFixedMaxPossibleWaterRate = allowOverflow ? dFixedMaxWaterRate : Math.Min(dSpareRoomWaterMass, dFixedMaxWaterRate);
+
+                // finds the minimum of these eight numbers (fixedMaxPossibleZZRate / fixedMaxZZRate). Could be more pretty with a custom Min8() function. Seriously. Put in the work, me. This is hideous. But it should be more effective than doing it with array.
+                dConsumptionStorageRatio = Math.Min(Math.Min(Math.Min(Math.Min(Math.Min(Math.Min(Math.Min(dFixedMaxPossibleHydrogenRate / dFixedMaxHydrogenRate, dFixedMaxPossibleHelium3Rate / dFixedMaxHelium3Rate), dFixedMaxPossibleHelium4Rate / dFixedMaxHelium4Rate), dFixedMaxPossibleMonoxideRate / dFixedMaxMonoxideRate), dFixedMaxPossibleNitrogenRate / dFixedMaxNitrogenRate), dFixedMaxPossibleWaterRate / dFixedMaxWaterRate), dFixedMaxPossibleDioxideRate / dFixedMaxDioxideRate), dFixedMaxPossibleMethaneRate / dFixedMaxMethaneRate);
+
+                // this consumes the resource
+                dRegolithConsumptionRate = _part.RequestResource(strRegolithResourceName, dConsumptionStorageRatio * dFixedConsumptionRate / dRegolithDensity) / TimeWarp.fixedDeltaTime * dRegolithDensity;
+
+                // this produces the products
+                double dHydrogenRateTemp = dRegolithConsumptionRate * dHydrogenMassByFraction;
+                double dHelium3RateTemp = dRegolithConsumptionRate * dHelium3MassByFraction;
+                double dHelium4RateTemp = dRegolithConsumptionRate * dHelium4MassByFraction;
+                double dMonoxideRateTemp = dRegolithConsumptionRate * dMonoxideMassByFraction;
+                double dDioxideRateTemp = dRegolithConsumptionRate * dDioxideMassByFraction;
+                double dMethaneRateTemp = dRegolithConsumptionRate * dMethaneMassByFraction;
+                double dNitrogenRateTemp = dRegolithConsumptionRate * dNitrogenMassByFraction;
+                double dWaterRateTemp = dRegolithConsumptionRate * dWaterMassByFraction;
+
+                dHydrogenProductionRate = -_part.RequestResource(strHydrogenResourceName, -dHydrogenRateTemp * TimeWarp.fixedDeltaTime / dHydrogenDensity) / TimeWarp.fixedDeltaTime * dHydrogenDensity;
+                dLiquidHelium3ProductionRate = -_part.RequestResource(strLiquidHelium3ResourceName, -dHelium3RateTemp * TimeWarp.fixedDeltaTime / dLiquidHelium3Density) / TimeWarp.fixedDeltaTime * dLiquidHelium3Density;
+                dLiquidHelium4ProductionRate = -_part.RequestResource(strLiquidHelium4ResourceName, -dHelium4RateTemp * TimeWarp.fixedDeltaTime / dLiquidHelium4Density) / TimeWarp.fixedDeltaTime * dLiquidHelium4Density;
+                dMonoxideProductionRate = -_part.RequestResource(strMonoxideResourceName, -dMonoxideRateTemp * TimeWarp.fixedDeltaTime / dMonoxideDensity) / TimeWarp.fixedDeltaTime * dMonoxideDensity;
+                dDioxideProductionRate = -_part.RequestResource(strDioxideResourceName, -dDioxideRateTemp * TimeWarp.fixedDeltaTime / dDioxideDensity) / TimeWarp.fixedDeltaTime * dDioxideDensity;
+                dMethaneProductionRate = -_part.RequestResource(strMethaneResourceName, -dMethaneRateTemp * TimeWarp.fixedDeltaTime / dMethaneDensity) / TimeWarp.fixedDeltaTime * dMethaneDensity;
+                dNitrogenProductionRate = -_part.RequestResource(strNitrogenResourceName, -dNitrogenRateTemp * TimeWarp.fixedDeltaTime / dNitrogenDensity) / TimeWarp.fixedDeltaTime * dNitrogenDensity;
+                dWaterProductionRate = -_part.RequestResource(strWaterResourceName, -dWaterRateTemp * TimeWarp.fixedDeltaTime / dWaterDensity) / TimeWarp.fixedDeltaTime * dWaterDensity;
+            }
+            else
+            {
+                dRegolithConsumptionRate = 0;
+                dHydrogenProductionRate = 0;
+                dLiquidHelium3ProductionRate = 0;
+                dLiquidHelium4ProductionRate = 0;
+                dMonoxideProductionRate = 0;
+                dDioxideProductionRate = 0;
+                dMethaneProductionRate = 0;
+                dNitrogenProductionRate = 0;
+                dWaterProductionRate = 0;
+            }
+            updateStatusMessage();
+        }
+
+        public void UpdateGUI()
+        {
+            if (_bold_label == null)
+            {
+                _bold_label = new GUIStyle(GUI.skin.label);
+                _bold_label.fontStyle = FontStyle.Bold;
+            }
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Power", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(PluginHelper.getFormattedPowerString(CurrentPower) + "/" + PluginHelper.getFormattedPowerString(PowerRequirements), GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Regolith Consumption", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(((dRegolithConsumptionRate / TimeWarp.fixedDeltaTime * GameConstants.HOUR_SECONDS).ToString("0.0000")) + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Regolith Available", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dAvailableRegolithMass.ToString("0.0000") + " mT / " + dMaxCapacityRegolithMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Hydrogen Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomHydrogenMass.ToString("0.0000") + " mT / " + dMaxCapacityHydrogenMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Hydrogen Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dHydrogenProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-3 Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomHelium3Mass.ToString("0.0000") + " mT / " + dMaxCapacityHelium3Mass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-3 Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dLiquidHelium3ProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-4 Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomHelium4Mass.ToString("0.0000") + " mT / " + dMaxCapacityHelium4Mass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Helium-4 Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dLiquidHelium4ProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Monoxide Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomMonoxideMass.ToString("0.0000") + " mT / " + dMaxCapacityMonoxideMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Monoxide Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dMonoxideProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Dioxide Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomDioxideMass.ToString("0.0000") + " mT / " + dMaxCapacityDioxideMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Carbon Dioxide Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dDioxideProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Methane Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomMethaneMass.ToString("0.0000") + " mT / " + dMaxCapacityMethaneMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Methane Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dMethaneProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Nitrogen Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomNitrogenMass.ToString("0.0000") + " mT / " + dMaxCapacityNitrogenMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Nitrogen Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dNitrogenProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Water Storage", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label(dSpareRoomWaterMass.ToString("0.0000") + " mT / " + dMaxCapacityWaterMass.ToString("0.0000") + " mT", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Water Production Rate", _bold_label, GUILayout.Width(labelWidth));
+            GUILayout.Label((dWaterProductionRate * GameConstants.HOUR_SECONDS).ToString("0.00000") + " mT/hour", GUILayout.Width(valueWidth));
+            GUILayout.EndHorizontal();
+        }
+
+        private void updateStatusMessage()
+        {
+            if (dRegolithConsumptionRate > 0)
+                _status = "Processing of Regolith Ongoing";
+            else if (CurrentPower <= 0.01 * PowerRequirements)
+                _status = "Insufficient Power";
+            else
+                _status = "Insufficient Storage, try allowing overflow";
+        }
+
+    }
+}

--- a/FNPlugin/Refinery/SolarWindProcessor.cs
+++ b/FNPlugin/Refinery/SolarWindProcessor.cs
@@ -199,7 +199,7 @@ namespace FNPlugin.Refinery
                 _solar_wind_consumption_rate = 0;
                 _hydrogen_production_rate = 0;
                 _liquid_helium3_production_rate = 0;
-                _liquid_helium3_production_rate = 0;
+                _liquid_helium4_production_rate = 0;
                 _monoxide_production_rate = 0;
                 _nitrogen_production_rate = 0;
                 _neon_production_rate = 0;

--- a/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
@@ -156,7 +156,20 @@ bulkheadProfiles = size2, size3, srf
         	amount = 0
         	maxAmount = 10
     	}
-
+		
+    	RESOURCE
+    	{
+        	name = Regolith
+        	amount = 0
+        	maxAmount = 100
+    	}
+		
+    	RESOURCE
+    	{
+        	name = SolarWind
+        	amount = 0
+        	maxAmount = 10
+    	}
     	RESOURCE
     	{
         	name = Boron

--- a/GameData/WarpPlugin/Patches/OrbitalScannerFix.cfg
+++ b/GameData/WarpPlugin/Patches/OrbitalScannerFix.cfg
@@ -42,7 +42,7 @@
 		MaxAbundanceAltitude = 500000
 		RequiresUnlock = true
 		ScannerType = 0
-		ResourceName = SolarWind
+		ResourceName = Regolith
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Patches/RadialDrillFix.cfg
+++ b/GameData/WarpPlugin/Patches/RadialDrillFix.cfg
@@ -32,7 +32,7 @@
 
     	RESOURCE
     	{
-        	name = SolarWind
+        	name = Regolith
         	amount = 0
         	maxAmount = 10
     	}
@@ -357,12 +357,12 @@
 	{
 		name = ModuleResourceHarvester
 		HarvesterType = 0
-		Efficiency = 1.5
-		ResourceName = SolarWind
-		ConverterName = SolarWind Harvester
-		StartActionName = Start SolarWind Harvester
-		StopActionName = Stop SolarWind Harvester
-		ToggleActionName = Toggle SolarWind Harvester
+		Efficiency = 3
+		ResourceName = Regolith
+		ConverterName = Regolith Harvester
+		StartActionName = Start Regolith Harvester
+		StopActionName = Stop Regolith Harvester
+		ToggleActionName = Toggle Regolith Harvester
 		ImpactTransform = ImpactTransform
 		ImpactRange = 5
 		AutoShutdown = true

--- a/GameData/WarpPlugin/Patches/SurfaceScanner.cfg
+++ b/GameData/WarpPlugin/Patches/SurfaceScanner.cfg
@@ -49,7 +49,7 @@
 	{
 		name = ModuleResourceScanner
 		ScannerType = 0
-		ResourceName = SolarWind
+		ResourceName = Regolith
 		MaxAbundanceAltitude = 1000
 		RequiresUnlock = false
 	}

--- a/GameData/WarpPlugin/ResourceConfigs/Regolith.cfg
+++ b/GameData/WarpPlugin/ResourceConfigs/Regolith.cfg
@@ -14,7 +14,7 @@
 // By default, no Regolith, unless it has no atmosphere and is relatively close to the Star
 GLOBAL_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	
 	Distribution
@@ -29,7 +29,7 @@ GLOBAL_RESOURCE
 
 PLANETARY_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Mercury
 	
@@ -45,7 +45,7 @@ PLANETARY_RESOURCE
 
 PLANETARY_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Moho
 	
@@ -61,7 +61,7 @@ PLANETARY_RESOURCE
 
 BIOME_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Moho
 	BiomeName = Northern Sinkhole Ridge
@@ -78,7 +78,7 @@ BIOME_RESOURCE
 
 BIOME_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Moho
 	BiomeName = Northern Sinkhole
@@ -96,7 +96,7 @@ BIOME_RESOURCE
 
 PLANETARY_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Gilly
 	
@@ -112,7 +112,7 @@ PLANETARY_RESOURCE
 
 PLANETARY_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Mun
 	
@@ -128,7 +128,7 @@ PLANETARY_RESOURCE
 
 PLANETARY_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Minmus
 	
@@ -144,7 +144,7 @@ PLANETARY_RESOURCE
 
 BIOME_RESOURCE
 {
-	ResourceName = SolarWind
+	ResourceName = Regolith
 	ResourceType = 0
 	PlanetName = Mun
 	BiomeName = Polar Crater

--- a/GameData/WarpPlugin/Resources/ResourceDefs.cfg
+++ b/GameData/WarpPlugin/Resources/ResourceDefs.cfg
@@ -73,6 +73,18 @@ RESOURCE_DEFINITION
 	color = .5,.5,1
 }
 
+RESOURCE_DEFINITION
+{
+	name = Regolith
+	density = 0.002
+	flowMode = ALL_VESSEL
+	transfer = PUMP
+	isTweakable = true
+	isVisible = true
+	unitCost = 35.5
+	volume = 1	
+}
+
 // Resources Tweaks
 @RESOURCE_DEFINITION[Antimatter]
 {


### PR DESCRIPTION
Added a new resource, Regolith, based on lunar regolith. Added a new processing capability to the ISRU part - breaking down regolith into its constituents. Changed part config patch for stock drill - it can now mine regolith instead of solar wind and can hold a small amount of regolith. ISRU can now hold a small amount of regolith (and solar wind) for basic processing. Substituted regolith for solar wind resource in patches for resource detectors.