### PR TITLE
Regolith collection now uses stock AbundanceRequest

### DIFF
--- a/FNPlugin/Refinery/InterstellarRefinery.cs
+++ b/FNPlugin/Refinery/InterstellarRefinery.cs
@@ -21,7 +21,7 @@ namespace FNPlugin.Refinery
         [KSPField(isPersistant = true)]
         private double lastPowerRatio;
         [KSPField(isPersistant = true)]
-        private string lastActivityName;
+        private string lastActivityName = "";
 
         [KSPField(isPersistant = true, guiActive = true, guiName = "Power Control"), UI_FloatRange(stepIncrement = 0.5f, maxValue = 100f, minValue = 0.5f)]
         public float powerPercentage = 100;

--- a/GameData/WarpPlugin/ResourceConfigs/Regolith.cfg
+++ b/GameData/WarpPlugin/ResourceConfigs/Regolith.cfg
@@ -11,7 +11,7 @@
 //Express all numbers as percentages 0.0-100.0, not 0.0-1.0!
 //
 
-// By default, no Regolith, unless it has no atmosphere and is relatively close to the Star
+// By default the usual distribution of Regolith
 GLOBAL_RESOURCE
 {
 	ResourceName = Regolith
@@ -19,11 +19,11 @@ GLOBAL_RESOURCE
 	
 	Distribution
 	{
-		PresenceChance = 0
-		MinAbundance = 0
-		MaxAbundance = 0
-		Variance = 0
-		Dispersal = 0
+		PresenceChance = 100
+		MinAbundance = 10
+		MaxAbundance = 35
+		Variance = 10
+		Dispersal = 3
 	}
 }
 
@@ -36,8 +36,8 @@ PLANETARY_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.2
-		MaxAbundance = 2
+		MinAbundance = 7
+		MaxAbundance = 25
 		Variance = 9
 		Dispersal = 1
 	}
@@ -52,8 +52,8 @@ PLANETARY_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.2
-		MaxAbundance = 2
+		MinAbundance = 7
+		MaxAbundance = 25
 		Variance = 9
 		Dispersal = 1
 	}
@@ -69,8 +69,8 @@ BIOME_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.5
-		MaxAbundance = 5
+		MinAbundance = 10
+		MaxAbundance = 25
 		Variance = 9
 		Dispersal = 1
 	}
@@ -86,8 +86,8 @@ BIOME_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 12
-		MaxAbundance = 20
+		MinAbundance = 25
+		MaxAbundance = 45
 		Variance = 9
 		Dispersal = 1
 	}
@@ -103,8 +103,8 @@ PLANETARY_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.1
-		MaxAbundance = 1
+		MinAbundance = 4
+		MaxAbundance = 8
 		Variance = 9
 		Dispersal = 1
 	}
@@ -119,8 +119,8 @@ PLANETARY_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.03
-		MaxAbundance = 0.3
+		MinAbundance = 3.5
+		MaxAbundance = 30
 		Variance = 9
 		Dispersal = 1
 	}
@@ -135,8 +135,8 @@ PLANETARY_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.015
-		MaxAbundance = 0.15
+		MinAbundance = 3.5
+		MaxAbundance = 25
 		Variance = 9
 		Dispersal = 1
 	}
@@ -152,13 +152,29 @@ BIOME_RESOURCE
 	Distribution
 	{
 		PresenceChance = 100
-		MinAbundance = 0.1
-		MaxAbundance = 1
+		MinAbundance = 4
+		MaxAbundance = 34
 		Variance = 10
 		Dispersal = 3
 	}
 }
 
+BIOME_RESOURCE
+{
+	ResourceName = Regolith
+	ResourceType = 0
+	PlanetName = Mun
+	BiomeName = Highlands
+	
+	Distribution
+	{
+		PresenceChance = 100
+		MinAbundance = 25
+		MaxAbundance = 55
+		Variance = 10
+		Dispersal = 3
+	}
+}
 
 
 


### PR DESCRIPTION
Added a new function to RegolithCollector that gets the regolith abundance from the stock system and added a wrapper function that combines this value with the value calculated by the KSPI-E system. This way there will always be some regolith (unless atmosphere etc.), but the stock system will provide aditional data (so people can scan for spots with higher density etc.).

Changed the regolith ratios in the ResourceConfigs, as the original values provided little to no benefit to the calculations.