### PR TITLE
Fix for atmospheric scoop

### DIFF
--- a/FNPlugin/Extensions/AtmosphericResourceHandler.cs
+++ b/FNPlugin/Extensions/AtmosphericResourceHandler.cs
@@ -196,7 +196,7 @@ namespace FNPlugin
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.Oxygen, "LqdOxygen", "Oxygen", "Oxygen");
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.CarbonDioxide, "LqdCO2", "CarbonDioxide", "CarbonDioxide");
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.CarbonMoxoxide, "LqdCO", "CarbonMoxoxide", "CarbonMoxoxide");
-                AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.Methane, "LqdCO", "LqdMethane", "Methane");
+                AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.Methane, "LqdMethane", "LqdMethane", "Methane");
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.Argon, "LqdArgon", "ArgonGas", "Argon");
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.Hydrogen, "LqdArgon", "Hydrogen", "Hydrogen");
                 AddResource(refBody, bodyAtmosphericComposition, InterstellarResourcesConfiguration.Instance.LqdDeuterium, "LqdDeuterium", "Deuterium", "Deuterium");

--- a/FNPlugin/Extensions/AtmosphericResourceHandler.cs
+++ b/FNPlugin/Extensions/AtmosphericResourceHandler.cs
@@ -254,8 +254,10 @@ namespace FNPlugin
                 Debug.Log("[KSPI] - added helum-3 to atmosphere eith abundance " + helium3Abundance);
                 bodyAtmosphericComposition.Add(new AtmosphericResource(InterstellarResourcesConfiguration.Instance.LqdHelium3, helium3Abundance, "Helium-3"));
             }
+            else if (bodyAtmosphericComposition.Any(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdHelium3))
+                Debug.Log("[KSPI] -  helium-3 is already present in atmosphere specification at " + bodyAtmosphericComposition.First(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdHelium3).ResourceAbundance);
             else
-                Debug.Log("[KSPI] -  helum-3 is already present in atmosphere specification at " + bodyAtmosphericComposition.First(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdHelium3).ResourceAbundance);
+                Debug.Log("[KSPI] -  No helium is present in atmosphere specification, helium-4 will not be added");
 
             // if deteurium is undefined, but hydrogen is, derive it
             if (!bodyAtmosphericComposition.Any(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdDeuterium) && bodyAtmosphericComposition.Any(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.Hydrogen))
@@ -266,8 +268,10 @@ namespace FNPlugin
                 Debug.Log("[KSPI] - added deuterium to atmosphere with abundance " + deuteriumAbundance);
                 bodyAtmosphericComposition.Add(new AtmosphericResource(InterstellarResourcesConfiguration.Instance.LqdDeuterium, deuteriumAbundance, "Deuterium"));
             }
-            else
+            else if (bodyAtmosphericComposition.Any(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdDeuterium)) 
                 Debug.Log("[KSPI] - deuterium is already present in atmosphere specification at " + bodyAtmosphericComposition.First(m => m.ResourceName == InterstellarResourcesConfiguration.Instance.LqdDeuterium).ResourceAbundance);
+            else 
+                Debug.Log("[KSPI] - No hydrogen is present in atmosphere specification, deuterium will not be added");
         }
 
         private static float GetAbundance(string resourceName, int refBody)


### PR DESCRIPTION
Without this changes AddRaresAndIsotopesToAdmosphereComposition method will throw exception when called for planet with no Helium or Hydrogen in atmosphere.

[LOG 16:02:34.833] [KSPI] - som of resource abundance = 1.33636998174675
[LOG 16:02:34.833] [KSPI] - added helum-4 to atmosphere with abundance 5.2E-06
[LOG 16:02:34.834] [KSPI] - added helum-3 to atmosphere eith abundance 7.176E-12
[LOG 16:02:34.834] [KSPI] - Exception while loading atmospheric resources : System.InvalidOperationException: Operation is not valid due to the current state of the object
  at System.Linq.Enumerable.First[AtmosphericResource] (IEnumerable`1 source, System.Func`2 predicate, Fallback fallback) [0x00000] in <filename unknown>:0 
  at System.Linq.Enumerable.First[AtmosphericResource] (IEnumerable`1 source, System.Func`2 predicate) [0x00000] in <filename unknown>:0 
  at FNPlugin.AtmosphericResourceHandler.AddRaresAndIsotopesToAdmosphereComposition (System.Collections.Generic.List`1 bodyAtmosphericComposition, .CelestialBody celestialBody) [0x00000] in <filename unknown>:0 
  at FNPlugin.AtmosphericResourceHandler.GetAtmosphericCompositionForBody (Int32 refBody) [0x00000] in <filename unknown>:0 
