### PR TITLE
Fixes for pivoted rectena and mirrors

### DIFF
--- a/FNPlugin/Microwave/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/Microwave/MicrowavePowerTransmitter.cs
@@ -68,9 +68,9 @@ namespace FNPlugin
         [KSPField(isPersistant = false, guiActiveEditor = true)]
         public int compatibleBeamTypes = 1;
 
-        [KSPField(isPersistant = false, guiActiveEditor = true)]
+        [KSPField(isPersistant = true, guiActiveEditor = true)]
         public double nativeWaveLength = 0.003189281;
-        [KSPField(isPersistant = false, guiActiveEditor = false)]
+        [KSPField(isPersistant = true, guiActiveEditor = false)]
         public double nativeAtmosphericAbsorptionPercentage = 10;
 
         //GUI 

--- a/GameData/WarpPlugin/Parts/Microwave/MicrowavePivotedRectenna/MicrowavePivotRectenna.cfg
+++ b/GameData/WarpPlugin/Parts/Microwave/MicrowavePivotedRectenna/MicrowavePivotRectenna.cfg
@@ -51,7 +51,7 @@ PART
 	{
 		name = BandwidthConverter
 		bandwidthName = infrared
-		minimumWavelength = 0.000075 // 7.5e-7		
+		minimumWavelength = 0.00000075 // 7.5e-7		
 		maximumWavelength = 0.001
     // 1.0e-3
 		efficiencyPercentage0 = 75

--- a/GameData/WarpPlugin/Parts/Microwave/PivotedInfraredMirror/PivotedInfraredMirror.cfg
+++ b/GameData/WarpPlugin/Parts/Microwave/PivotedInfraredMirror/PivotedInfraredMirror.cfg
@@ -39,8 +39,8 @@ PART
 		buildInRelay = false
 		isMirror = true
 		apertureDiameter = 10
-		wavelength = 0.000010
-		atmosphericAbsorption = 0.44
+		nativeWaveLength = 0.000010
+		nativeAtmosphericAbsorption = 0.44
 		minimumRelayWavelenght = 0.000009
 		maximumRelayWavelenght = 0.001
 		efficiencyPercentage = 95

--- a/GameData/WarpPlugin/Parts/Microwave/PivotedLightMirror/PivotedLightMirror.cfg
+++ b/GameData/WarpPlugin/Parts/Microwave/PivotedLightMirror/PivotedLightMirror.cfg
@@ -39,8 +39,8 @@ PART
 		buildInRelay = true
 		isMirror = true
 		apertureDiameter = 10
-		wavelength = 0.0000007
-		atmosphericAbsorption = 0.50
+		nativeWavelength = 0.0000007
+		nativeAtmosphericAbsorption = 0.50
 		minimumRelayWavelenght = 0.0000001
 		maximumRelayWavelenght = 0.000009
 		efficiencyPercentage = 99.9


### PR DESCRIPTION
1) Fix for double pivoted rectena is just correct wavelength (added to zeros).

2) Fix for mirrors, theirs wavelength and atmosperic absorbtion fields always rewriting by nativeWaveLength, that initialized with 0.003189281, and newer changes. Due to it, mirrors receives energy in infrared/UV and translates in microvawe, so next mirror relay or infrared/UV receiver can't handle this signal. I made nativeWaveLength persistent and changed configs for mirrors. Not sure if this approach is coreect.