### PR TITLE
Quick fix for PivotedLightMirror, correct parameter name for nativeWaveLength

### DIFF
--- a/GameData/WarpPlugin/Parts/Microwave/PivotedLightMirror/PivotedLightMirror.cfg
+++ b/GameData/WarpPlugin/Parts/Microwave/PivotedLightMirror/PivotedLightMirror.cfg
@@ -39,7 +39,7 @@ PART
 		buildInRelay = true
 		isMirror = true
 		apertureDiameter = 10
-		nativeWavelength = 0.0000007
+		nativeWaveLength = 0.0000007
 		nativeAtmosphericAbsorption = 0.50
 		minimumRelayWavelenght = 0.0000001
 		maximumRelayWavelenght = 0.000009


### PR DESCRIPTION
Btw, I want to rename it to nativeWavelength in all configs and sources, to make it consistent with other parameter names like minimumRelayWavelenght and maximumRelayWavelenght. What do you think about that?