### PR TITLE
Added more oceanic resource definitions

### DIFF
--- a/GameData/WarpPlugin/PlanetResourceData/oceanicresourcedefinitions.cfg
+++ b/GameData/WarpPlugin/PlanetResourceData/oceanicresourcedefinitions.cfg
@@ -204,6 +204,14 @@ OCEANIC_RESOURCE_DEFINITION
 }
 OCEANIC_RESOURCE_DEFINITION
 {
+    name = TitanEthane
+    guiName = Ethane
+    celestialBodyName = Titan
+    abundance = 0.05
+    resourceName = Ethane
+}
+OCEANIC_RESOURCE_DEFINITION
+{
     name = LaytheWater
     guiName = Water
     celestialBodyName = Laythe
@@ -300,9 +308,143 @@ OCEANIC_RESOURCE_DEFINITION
     name = SlateWater
     guiName = Water
     celestialBodyName = Slate
-    abundance = .80
+    abundance = 0.80
     resourceName = Water
 }
-
-
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusWater
+    guiName = Water
+    celestialBodyName = Enceladus
+    abundance = 0.95
+    resourceName = Water
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusSodium
+    guiName = Sodium
+    celestialBodyName = Enceladus
+    abundance = 0.052
+    resourceName = Sodium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusChlorine
+    guiName = Chlorine
+    celestialBodyName = Enceladus
+    abundance = 0.034
+    resourceName = Chlorine
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusPotassium
+    guiName = Potassium
+    celestialBodyName = Enceladus
+    abundance = 0.0036
+    resourceName = Potassium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusMethane
+    guiName = Methane
+    celestialBodyName = Enceladus
+    abundance = 0.000002
+    resourceName = Methane
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EnceladusCarbonDioxide
+    guiName = CO2
+    celestialBodyName = Enceladus
+    abundance = 0.000005
+    resourceName = LqdCO2
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaWater
+    guiName = Water
+    celestialBodyName = Europa
+    abundance = 0.98
+    resourceName = Water
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaMagnesium
+    guiName = Magnesium
+    celestialBodyName = Europa
+    abundance = 0.00431
+    resourceName = Magnesium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaSodium
+    guiName = Sodium
+    celestialBodyName = Europa
+    abundance = 0.000535
+    resourceName = Sodium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaPotassium
+    guiName = Potassium
+    celestialBodyName = Europa
+    abundance = 0.000535
+    resourceName = Potassium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaCalcium
+    guiName = Calcium
+    celestialBodyName = Europa
+    abundance = 0.00455
+    resourceName = Calcium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaSulfate
+    guiName = Sulfate
+    celestialBodyName = Europa
+    abundance = 0.00603
+    resourceName = Sulfate
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaChlorine
+    guiName = Chlorine
+    celestialBodyName = Europa
+    abundance = 0.00013
+    resourceName = Chlorine
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = EuropaCarbonate
+    guiName = Carbonate
+    celestialBodyName = Europa
+    abundance = 0.00384
+    resourceName = Carbonate
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = GanymedeWater
+    guiName = Water
+    celestialBodyName = Ganymede
+    abundance = 0.9
+    resourceName = Water
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = GanymedeMagnesium
+    guiName = Magnesium
+    celestialBodyName = Ganymede
+    abundance = 0.05
+    resourceName = Magnesium
+}
+OCEANIC_RESOURCE_DEFINITION
+{
+    name = GanymedeSulfate
+    guiName = Sulfate
+    celestialBodyName = Ganymede
+    abundance = 0.05
+    resourceName = Sulfate
+}
 }


### PR DESCRIPTION
Added definitions for oceanic resource for Ganymede, Europa, Enceladus and one for Titan (all are used in generating definitions for planets without explicitly defined oceanic resources).
Some resources are not currently used as far as I know (potassium etc.), but I added them anyway - should
not pose any trouble and will be available in the future if we ever need/want to add them (as a propellant or whatever).