### PR TITLE
Generator tweaks, new PR

### DIFF
--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1105,6 +1105,21 @@ namespace FNPlugin
             }
         }
 
+        private void OnEditorDetach()
+        {
+            foreach (var node in part.attachNodes)
+            {
+                if (node.attachedPart == null) continue;
+
+                var generator = node.attachedPart.FindModuleImplementing<FNGenerator>();
+                if (generator != null)
+                {
+                    generator.DetachFromThermalSource();
+                    generator.FindAndAttachToThermalSource();
+                }
+            }
+        }
+
         public virtual void Update()
         {
             currentRawPowerOutput = RawPowerOutput;

--- a/FNPlugin/Wasteheat/FNGenerator.cs
+++ b/FNPlugin/Wasteheat/FNGenerator.cs
@@ -114,8 +114,6 @@ namespace FNPlugin
         public double requiredMegawattCapacity;
         [KSPField(isPersistant = false, guiActive = false, guiName = "Heat Exchange Divisor")]
         public float heat_exchanger_thrust_divisor;
-        [KSPField(isPersistant = false, guiActive = true, guiName = "Requested Power", guiUnits = " MW", guiFormat = "F2")]
-        public double requestedPower_f;
         [KSPField(isPersistant = false, guiActive = true, guiName = "Cold Bath Temp", guiUnits = "K",  guiFormat = "F2")]
         public double coldBathTemp = 500;
         [KSPField(isPersistant = false, guiActive = true, guiName = "Hot Bath Temp", guiUnits = "K", guiFormat = "F2")]
@@ -604,10 +602,7 @@ namespace FNPlugin
                     _totalEff = Math.Min(pCarnotEff, carnotEff * pCarnotEff * attachedPowerSource.ThermalEnergyEfficiency);
 
                     if (_totalEff <= 0.01 || coldBathTemp <= 0 || hotBathTemp <= 0 || maxThermalPower <= 0)
-                    {
-                        requestedPower_f = 0;
                         return;
-                    }
 
                     attachedPowerSource.NotifyActiveThermalEnergyGenerator(_totalEff, ElectricGeneratorType.thermal);
 
@@ -616,7 +611,6 @@ namespace FNPlugin
                     double thermal_power_requested_per_second = Math.Max(Math.Min(maxThermalPower, thermal_power_currently_needed_per_second), 0);
                     double reactor_power_requested_per_second = Math.Max(Math.Min(maxReactorPower, thermal_power_currently_needed_per_second), 0);
 
-                    requestedPower_f = thermal_power_requested_per_second;
                     attachedPowerSource.RequestedThermalHeat = thermal_power_requested_per_second;
 
                     double thermal_power_received_per_second = consumeFNResourcePerSecond(thermal_power_requested_per_second, FNResourceManager.FNRESOURCE_THERMALPOWER);
@@ -646,15 +640,14 @@ namespace FNPlugin
                 {
                     _totalEff = isupgraded ? upgradedDirectConversionEff : directConversionEff;
 
-                    attachedPowerSource.NotifyActiveChargedEnergyGenerator(_totalEff, ElectricGeneratorType.charged_particle);
-
                     if (_totalEff <= 0) return;
 
+                    attachedPowerSource.NotifyActiveChargedEnergyGenerator(_totalEff, ElectricGeneratorType.charged_particle);
                     double charged_power_currently_needed = CalculateElectricalPowerCurrentlyNeeded();
 
-                    requestedPower_f = Math.Max(Math.Min(maxChargedPower, charged_power_currently_needed / _totalEff), 0);
+                    double charged_power_requested_fixed = Math.Max(Math.Min(maxChargedPower, charged_power_currently_needed / _totalEff) * TimeWarp.fixedDeltaTime, 0);
 
-                    double input_power = consumeFNResource(requestedPower_f * TimeWarp.fixedDeltaTime, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
+                    double input_power = consumeFNResource(charged_power_requested_fixed, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
 
                     var effective_input_power = input_power * _totalEff;
 

--- a/FNPlugin/Wasteheat/FNGenerator.cs
+++ b/FNPlugin/Wasteheat/FNGenerator.cs
@@ -304,6 +304,7 @@ namespace FNPlugin
                     upgradePartModule();
                 }
                 part.OnEditorAttach += OnEditorAttach;
+                part.OnEditorDetach += OnEditorDetach;
                 return;
             }
 
@@ -348,20 +349,28 @@ namespace FNPlugin
             UpdateHeatExchangedThrustDivisor();
         }
 
-        /// <summary>
-        /// Finds the nearest avialable thermalsource and update effective part mass
-        /// </summary>
-        public void FindAndAttachToThermalSource()
+        private void OnEditorDetach()
         {
-            // disconnect
+            DetachFromThermalSource();
+        }
+
+        public void DetachFromThermalSource()
+        {
             if (attachedPowerSource != null)
             {
                 if (chargedParticleMode)
                     attachedPowerSource.ConnectedChargedParticleElectricGenerator = null;
                 else
                     attachedPowerSource.ConnectedThermalElectricGenerator = null;
+                attachedPowerSource = null;
             }
+        }
 
+        /// <summary>
+        /// Finds the nearest avialable thermalsource and update effective part mass
+        /// </summary>
+        public void FindAndAttachToThermalSource()
+        {
             // first look if part contains an thermal source
             attachedPowerSource = part.FindModulesImplementing<IPowerSource>().FirstOrDefault();
             if (attachedPowerSource != null)

--- a/FNPlugin/Wasteheat/FNGenerator.cs
+++ b/FNPlugin/Wasteheat/FNGenerator.cs
@@ -633,22 +633,26 @@ namespace FNPlugin
 
                     _totalEff = Math.Min(pCarnotEff, carnotEff * pCarnotEff * attachedPowerSource.ThermalEnergyEfficiency);
 
-                    if (_totalEff <= 0.01 || coldBathTemp <= 0 || hotBathTemp <= 0 || maxThermalPower <= 0) return;
+                    if (_totalEff <= 0.01 || coldBathTemp <= 0 || hotBathTemp <= 0 || maxThermalPower <= 0)
+                        return;
 
                     attachedPowerSource.NotifyActiveThermalEnergyGenerator(_totalEff, ElectricGeneratorType.thermal);
 
-                    double thermal_power_currently_needed = CalculateElectricalPowerCurrentlyNeeded();
-                    double thermal_power_requested_fixed = Math.Max(Math.Min(maxThermalPower, thermal_power_currently_needed / _totalEff) * TimeWarp.fixedDeltaTime, 0);
+                    double thermal_power_currently_needed_per_second = CalculateElectricalPowerCurrentlyNeeded();
 
-                    attachedPowerSource.RequestedThermalHeat = thermal_power_requested_fixed / TimeWarp.fixedDeltaTime;
+                    double thermal_power_requested_per_second = Math.Max(Math.Min(maxThermalPower, thermal_power_currently_needed_per_second), 0);
 
-                    double input_power = consumeFNResource(thermal_power_requested_fixed, FNResourceManager.FNRESOURCE_THERMALPOWER);
-                    var effective_input_power = input_power * _totalEff;
+                    attachedPowerSource.RequestedThermalHeat = thermal_power_requested_per_second;
+
+                    double thermal_power_received_per_second = consumeFNResourcePerSecond(thermal_power_requested_per_second, FNResourceManager.FNRESOURCE_THERMALPOWER);
+
+                    var effective_input_power_per_second = thermal_power_received_per_second * _totalEff;
 
                     if (!CheatOptions.IgnoreMaxTemperature)
-                        consumeFNResourcePerSecond(effective_input_power, FNResourceManager.FNRESOURCE_WASTEHEAT);
+                        consumeFNResourcePerSecond(effective_input_power_per_second, FNResourceManager.FNRESOURCE_WASTEHEAT);
 
-                    electricdtps = Math.Max(effective_input_power / TimeWarp.fixedDeltaTime, 0.0);
+                    electricdtps = Math.Max(effective_input_power_per_second, 0.0);
+
                     max_electricdtps = maxThermalPower * _totalEff;
                 }
                 else // charged particle mode
@@ -658,11 +662,12 @@ namespace FNPlugin
                     if (_totalEff <= 0) return;
 
                     attachedPowerSource.NotifyActiveChargedEnergyGenerator(_totalEff, ElectricGeneratorType.charged_particle);
-
                     double charged_power_currently_needed = CalculateElectricalPowerCurrentlyNeeded();
+
                     double charged_power_requested_fixed = Math.Max(Math.Min(maxChargedPower, charged_power_currently_needed / _totalEff) * TimeWarp.fixedDeltaTime, 0);
 
                     double input_power = consumeFNResource(charged_power_requested_fixed, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
+
                     var effective_input_power = input_power * _totalEff;
 
                     if (!CheatOptions.IgnoreMaxTemperature)

--- a/FNPlugin/Wasteheat/FNGenerator.cs
+++ b/FNPlugin/Wasteheat/FNGenerator.cs
@@ -304,8 +304,6 @@ namespace FNPlugin
                     upgradePartModule();
                 }
                 part.OnEditorAttach += OnEditorAttach;
-
-                FindAndAttachToThermalSource();
                 return;
             }
 

--- a/FNPlugin/Wasteheat/FNGenerator.cs
+++ b/FNPlugin/Wasteheat/FNGenerator.cs
@@ -609,21 +609,10 @@ namespace FNPlugin
                     double thermal_power_currently_needed_per_second = CalculateElectricalPowerCurrentlyNeeded();
 
                     double thermal_power_requested_per_second = Math.Max(Math.Min(maxThermalPower, thermal_power_currently_needed_per_second), 0);
-                    double reactor_power_requested_per_second = Math.Max(Math.Min(maxReactorPower, thermal_power_currently_needed_per_second), 0);
 
                     attachedPowerSource.RequestedThermalHeat = thermal_power_requested_per_second;
 
                     double thermal_power_received_per_second = consumeFNResourcePerSecond(thermal_power_requested_per_second, FNResourceManager.FNRESOURCE_THERMALPOWER);
-
-                    if (thermal_power_received_per_second < reactor_power_requested_per_second && attachedPowerSource.ChargedPowerRatio > 0 && attachedPowerSource.EfficencyConnectedChargedEnergyGenerator == 0)
-                    {
-                        var requested_charged_power_per_second = reactor_power_requested_per_second - thermal_power_received_per_second;
-
-                        if (requested_charged_power_per_second < 0.000025)
-                            thermal_power_received_per_second += requested_charged_power_per_second;
-                        else
-                            thermal_power_received_per_second += consumeFNResourcePerSecond(requested_charged_power_per_second, FNResourceManager.FNRESOURCE_CHARGED_PARTICLES);
-                    }
 
                     var effective_input_power_per_second = thermal_power_received_per_second * _totalEff;
 
@@ -632,9 +621,7 @@ namespace FNPlugin
 
                     electricdtps = Math.Max(effective_input_power_per_second, 0.0);
 
-                    var effectiveMaxThermalPower = attachedPowerSource.EfficencyConnectedChargedEnergyGenerator == 0 ? maxReactorPower : maxThermalPower;
-
-                    max_electricdtps = effectiveMaxThermalPower * _totalEff;
+                    max_electricdtps = maxThermalPower * _totalEff;
                 }
                 else // charged particle mode
                 {


### PR DESCRIPTION
One small fix for TP generator for when paired with disabled CP generator it would use CP to generate more power than possible with only TP (talking single mode generators here, but it affects dual mode generator with CP mode off).

Second change changes how generators get paired with reactors. I made it so that each generator checks only parent and child parts for IThermalSource (parent first, if no luck go for children). If suitable part if found and it has no generator assigned in matching category (CP or TP) then we take that spot. If no suitable part is found then generator is orphaned and won't work. This way reactor can have only one CP and one TP generator, each generator will feed of only one reactor and generators have to be directly connected to reactors.