### PR TITLE
Wrapper tanks has IFS function disabled, I Think this is mistake.

### DIFF
--- a/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperCap.cfg
+++ b/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperCap.cfg
@@ -103,7 +103,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank large.cfg
+++ b/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank large.cfg
@@ -135,7 +135,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank medium.cfg
+++ b/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank medium.cfg
@@ -93,7 +93,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank small.cfg
+++ b/GameData/InterstellarFuelSwitch/Parts/WrapperTank/WrapperTank small.cfg
@@ -93,7 +93,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperCap.cfg
+++ b/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperCap.cfg
@@ -48,8 +48,8 @@ PART
 	basePartMass = 0.01
 	baseResourceMassDivider = 10
 	displayCurrentTankCost = false
-	availableInFlight = true
-	availableInEditor = false
+	availableInFlight = false
+	availableInEditor = true
 	orderBySwitchName = true
 	showInfo = true
 	hasGUI = true

--- a/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank - X96.cfg
+++ b/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank - X96.cfg
@@ -135,7 +135,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank X24.cfg
+++ b/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank X24.cfg
@@ -94,7 +94,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true

--- a/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank X48.cfg
+++ b/GameData/WarpPlugin/Parts/FuelTank/WrapperTank/WrapperTank X48.cfg
@@ -93,7 +93,7 @@ PART
 		baseResourceMassDivider = 10
 		displayCurrentTankCost = false
 		availableInFlight = false
-		availableInEditor = false
+		availableInEditor = true
 		orderBySwitchName = true
 		showInfo = true
 		hasGUI = true


### PR DESCRIPTION
IFS tanks configured with lots of fuel combinations  and disabled switch function, looks strange. Also ability to change fuel in editor was in early 1.12 versions, and "availableInEditor" option was false from initial commit, so I suspect that code was changed to use this option and config should be updated accordingly.