### PR TITLE
increase unfocused range for MSR restart/shutdown

### DIFF
--- a/FNPlugin/Reactors/InterstellarFissionMSRGC.cs
+++ b/FNPlugin/Reactors/InterstellarFissionMSRGC.cs
@@ -102,7 +102,7 @@ namespace FNPlugin
             fuelModeStr = CurrentFuelMode.ModeGUIName;
         }
 
-        [KSPEvent(guiName = "Manual Restart", externalToEVAOnly = true, guiActiveUnfocused = true, unfocusedRange = 3.0f)]
+        [KSPEvent(guiName = "Manual Restart", externalToEVAOnly = true, guiActiveUnfocused = true, unfocusedRange = 3.5f)]
         public void ManualRestart()
         {
             // verify any of the fuel types has at least 50% avaialbility inside the reactor
@@ -110,7 +110,7 @@ namespace FNPlugin
                 IsEnabled = true;
         }
 
-        [KSPEvent(guiName = "Manual Shutdown", externalToEVAOnly = true, guiActiveUnfocused = true, unfocusedRange = 3.0f)]
+        [KSPEvent(guiName = "Manual Shutdown", externalToEVAOnly = true, guiActiveUnfocused = true, unfocusedRange = 3.5f)]
         public void ManualShutdown()
         {
             IsEnabled = false;


### PR DESCRIPTION
Is there a reason unfocusedRange is set to 3.0 for molten salt reactors? It's 3.5 for pebble bed reactors, and I can't for the life of me do a manual restart/shutdown on molten salt reactors that are larger than 5 meters. I can file a bug report, if need be.