### PR TITLE
LiH production and B9 radiators

### DIFF
--- a/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
@@ -888,6 +888,70 @@ bulkheadProfiles = size2, size3, srf
 		}
 	}
 
+	// 2Li + H2 = 2 LiH
+	// 2*N(Li) + N(H2) = 2*N(LiH); N - number of molecules
+	// N=m/M=V*p/M; V - volume, p - density, M - molar mass
+	// Ratio = 10*k*p/M; 10 - scaling coefficient, k - number of molecules in reaction
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = LiH manufacturer
+		StartActionName = Start create LiH
+		StopActionName = Stop create LiH
+		AutoShutdown = true
+		TemperatureModifier
+		{
+			key = 0 50000
+			key = 750 25000
+			key = 1000 5000
+			key = 1250 2500	
+			key = 2000 2500	
+			key = 4000 0
+		}				
+		GeneratesHeat = true
+		DefaultShutoffTemp = .8
+		ThermalEfficiency 
+		{
+			key = 0 0 0 0
+			key = 500 0.9 0 0
+			key = 1000 1.0 0 0
+			key = 1250 0.9 0 0
+			key = 1500 0.5 0 0
+			key = 3000 0.0 0 0 
+		}
+
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = ConverterSkill
+		EfficiencyBonus = 1
+
+		INPUT_RESOURCE
+		{
+			ResourceName = Lithium
+			Ratio = 1.54 //2*0.534/6.94
+			FlowMode = STAGE_PRIORITY_FLOW
+  		}
+		INPUT_RESOURCE
+		{
+			ResourceName = Hydrogen
+			Ratio = 0.45 //0.045/1
+			FlowMode = STAGE_PRIORITY_FLOW
+  		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 30 //????
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = LithiumHydride
+			Ratio = 1.96 //2*0.78/7.95
+			DumpExcess = false
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+	}
+
 	MODULE
 	{
 		name = ModuleCoreHeat
@@ -905,5 +969,4 @@ bulkheadProfiles = size2, size3, srf
 		CoreShutdownTemp = 4000		//At what core temperature do we shut down all generators on this part?
 		MaxCoolant = 500		//Maximum amount of radiator capacity we can consume - 50 = 1 small
 	}
-
 }

--- a/GameData/WarpPlugin/Parts/Utility/Liquidficator/UniversalLiquidficatorWedge.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/Liquidficator/UniversalLiquidficatorWedge.cfg
@@ -278,8 +278,8 @@ PART
 	MODULE
 	{
 		name = InterstellarResourceConverter
-		primaryResourceNames = LqdWater
-		secondaryResourceNames = Water
+		primaryResourceNames = Water
+		secondaryResourceNames = LqdWater
 		maxPowerPrimary = 10
 		maxPowerSecondary = 10
 		percentageMinValue = 0

--- a/GameData/WarpPlugin/Patches/b9aero.cfg
+++ b/GameData/WarpPlugin/Patches/b9aero.cfg
@@ -168,6 +168,91 @@
     }
 }
 
+@PART[B9_Body_Mk2_Cargo_Bay_1m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 1.65 
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+	showColorHeat = False
+    }
+}
+
+@PART[B9_Body_Mk2_Cargo_Bay_2m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 3.3 // same as stock mk2
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+	showColorHeat = False
+    }
+}
+
+@PART[B9_Body_Mk1_Cargo_Bay_200m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 3 
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+	showColorHeat = False
+    }
+}
+
+@PART[B9_Body_Mk1_Cargo_Bay_100m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 1.5
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+	showColorHeat = False
+    }
+}
+
+@PART[B9_Body_Mk1_Cargo_Bay_050m]
+{
+    MODULE
+    {
+        name = FNRadiator
+        isDeployable = false
+        radiatorTemp = 1350
+        radiatorArea = 0.75
+        originalName = Mo Li Heat Pipe
+        upgradeCost = 5
+        upgradedName = Graphene Radiator
+        upgradedRadiatorTemp = 3500
+        upgradeTechReq = experimentalElectrics
+	showColorHeat = False
+    }
+}
+
 @PART[B9_Engine_SABRE_S]
 {
     MODULE


### PR DESCRIPTION
1) Quick fix to liquidficator.
2) Added LiH production to all-in-one ISRU via stock production module.
3) Added KSPI radiators to B9 Mk2 and Mk1 cargo bays.