### PR TITLE
Fix multiple FOR, AFTER, FINAL specifiers on patches

### DIFF
--- a/GameData/WarpPlugin/Patches/IntegrationFixes.cfg
+++ b/GameData/WarpPlugin/Patches/IntegrationFixes.cfg
@@ -1,4 +1,4 @@
-@PART[M2X_Reactor_DustyPlasma]:NEEDS[KSPIntegration]:AFTER[KSPIntegration]:FOR[WarpPlugin]
+@PART[M2X_Reactor_DustyPlasma]:NEEDS[KSPIntegration]:AFTER[KSPIntegration]
 {
     @MODULE[InterstellarFissionPBDP]
     {
@@ -6,7 +6,7 @@
     }
 }
 
-@PART[M2X_Reactor_Tokamak]:NEEDS[KSPIntegration]:AFTER[KSPIntegration]:FOR[WarpPlugin]
+@PART[M2X_Reactor_Tokamak]:NEEDS[KSPIntegration]:AFTER[KSPIntegration]
 {
     @MODULE[InterstellarFissionPBDP]
     {

--- a/GameData/WarpPlugin/Patches/NFTEnginesFix.cfg
+++ b/GameData/WarpPlugin/Patches/NFTEnginesFix.cfg
@@ -73,7 +73,7 @@
    }
 }
 
-@PART[ionEngine]:NEEDS[!NearFutureElectrical,!SETI,NearFuturePropulsion]:AFTER[NearFuturePropulsion]:FOR[WarpPlugin]
+@PART[ionEngine]:NEEDS[!NearFutureElectrical,!SETI,NearFuturePropulsion]:AFTER[NearFuturePropulsion]
 {
    @MODULE[ModuleEnginesFX]
    {

--- a/GameData/WarpPlugin/Patches/RealFuelsFix.cfg
+++ b/GameData/WarpPlugin/Patches/RealFuelsFix.cfg
@@ -142,7 +142,7 @@
     @resourceName = HTP
 }
 
-@ATMOSPHERIC_RESOURCE_PACK_DEFINITION[InterstellarAtmosphericPack]:FINAL:NEEDS[RealFuels]:FOR[WarpPlugin]
+@ATMOSPHERIC_RESOURCE_PACK_DEFINITION[InterstellarAtmosphericPack]:FINAL:NEEDS[RealFuels]
 {
     @ATMOSPHERIC_RESOURCE_DEFINITION[KerbinOxygen]
     {

--- a/GameData/WarpPlugin/Patches/RemoteTechFix.cfg
+++ b/GameData/WarpPlugin/Patches/RemoteTechFix.cfg
@@ -1,4 +1,4 @@
-@PART[computerCore]:NEEDS[RemoteTech]:FOR[WarpPlugin]:FINAL
+@PART[computerCore]:NEEDS[RemoteTech]:FINAL
 {
 	!MODULE[ModuleSPU]{}
 

--- a/GameData/WarpPlugin/Patches/TACLifeSupportFix.cfg
+++ b/GameData/WarpPlugin/Patches/TACLifeSupportFix.cfg
@@ -12,7 +12,7 @@
 //	@WaterResourceName = Water
 //}
 
-@TANK_DEFINITION[*]:HAS[@TANK[Kerosene]&!TANK[Water]]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]:FOR[WarpPlugin]
+@TANK_DEFINITION[*]:HAS[@TANK[Kerosene]&!TANK[Water]]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
 {
 	!TANK[LqdWater] {} //just in case :)
 	+TANK[Kerosene]
@@ -37,7 +37,7 @@
 //	}
 //}
 
-//@PLANETARY_RESOURCE_DEFINITION[Water]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]:FOR[WarpPlugin]
+//@PLANETARY_RESOURCE_DEFINITION[Water]:NEEDS[TacLifeSupport]:AFTER[TacLifeSupport]
 //{
 //	@resourceName = Water
 //}
@@ -47,7 +47,7 @@
 //	@resourceName = Water //LqdWater
 //}
 
-//@WARP_PLUGIN_SETTINGS[*]:NEEDS[TacLifeSupport]:FOR[WarpPlugin]:FOR[WarpPlugin]
+//@WARP_PLUGIN_SETTINGS[*]:NEEDS[TacLifeSupport]:FOR[WarpPlugin]
 //{
 //	@WaterResourceName = Water //LqdWater
 //}


### PR DESCRIPTION
As of at least Mod Manager 3.0.1, patches are not allowed to have
more than one time specifier.

This has been tested with TAC life support.