### PR TITLE
Fix for issue #55

### DIFF
--- a/GameData/WarpPlugin/Parts/Microwave/CircularSolarPhotovoltaicReceiver/CircularPanel.cfg
+++ b/GameData/WarpPlugin/Parts/Microwave/CircularSolarPhotovoltaicReceiver/CircularPanel.cfg
@@ -45,7 +45,7 @@ maxTemp = 3200
 		retractable = true
 
 		animationName = deploy
-		raycastTransformName = SunCatcher
+		raycastTransformName = SunPivot
 		pivotName = SunPivot
 
 		resourceName = ElectricCharge


### PR DESCRIPTION
I really need circular solar panels to work. The proper solution lies with modifying the SunCatcher plane in Yogui's .mu, but I'm not sure if this would require relicensing from Yogui. 

From some tinkering I discovered the problem goes away by setting raycastTransformName to SunPivot. This change still needs to be applied to other circular receivers.