### PR TITLE
airospikepatch for #229

### DIFF
--- a/FNPlugin/Propulsion/FusionECU2.cs
+++ b/FNPlugin/Propulsion/FusionECU2.cs
@@ -489,7 +489,7 @@ namespace FNPlugin
 
             if (throttle > 0)
             {
-                if (vessel.atmDensity > maxAtmosphereDensity)
+                if (maxAtmosphereDensity => 0 && vessel.atmDensity > maxAtmosphereDensity)
                     ShutDown("Inertial Fusion cannot operate in atmosphere!");
 
                 if (radhazard && rad_safety_features)

--- a/GameData/WarpPlugin/Parts/Engines/ZPinchAirospike/part.cfg
+++ b/GameData/WarpPlugin/Parts/Engines/ZPinchAirospike/part.cfg
@@ -130,7 +130,7 @@ PART
 		maxTemp = 2500
 		gearDivider = 0.3333
 		wasteHeatMultiplier = 1
-		maxAtmosphereDensity = 1000
+		maxAtmosphereDensity = -1
 		resourceSwitching = false
     	}
 


### PR DESCRIPTION
The fusion airospike doesnt need the maxAtmosphereDensity but its not worth writing more dedicated code just for it.

Using maxAtmosphereDensity = -1 you can now disable it, but if need be it can be easily reenabled in the future. Other fix option would be just removing said lines completely.

Fixes #229