### PR TITLE
Update EC2503.cfg

### DIFF
--- a/GameData/InterstellarFuelSwitch/Parts/TankRevamp/EC2503.cfg
+++ b/GameData/InterstellarFuelSwitch/Parts/TankRevamp/EC2503.cfg
@@ -119,7 +119,7 @@ PART
     	{
 		name		=	ModuleElementRadioactiveDecay
 		decayConstant 	=	1.0e-6
-		resourceName	=	StoredPower
+		resourceName	=	KilowattHour
 		decayProduct	=	WasteHeat
 		convFactor	=	0.001
     	}


### PR DESCRIPTION
ModuleElementRadioactiveDecay had StoredCharge listd as resource name instead of KilowattHour - unless I am mistaken.

0K