### PR TITLE
Resolved error in JumpDrive.cfg

### DIFF
--- a/GameData/WarpPlugin/Patches/JumpDrive.cfg
+++ b/GameData/WarpPlugin/Patches/JumpDrive.cfg
@@ -1,4 +1,4 @@
-@PART[JumpDrive,JumpBeacon]:[!NearFutureElectrical,!SETI]:FOR[WarpPlugin]
+@PART[JumpDrive,JumpBeacon]:NEEDS[!NearFutureElectrical,!SETI]:FOR[WarpPlugin]
 {
         @PROPELLANT[RESOURCE]
         {


### PR DESCRIPTION
A typo/syntax error is causing a MM error. Just needed to pop in "NEEDS" to get it working.