### PR TITLE
Update CRPResources.cfg

### DIFF
--- a/GameData/InterstellarFuelSwitch/Resources/CRPResources.cfg
+++ b/GameData/InterstellarFuelSwitch/Resources/CRPResources.cfg
@@ -382,8 +382,8 @@ RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
 RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
 {
     	name = HTP
-	abbreviation = HTP
-	displayName = Hydrogen Peroxide
+	abbreviation = #LOC_IFS_Resources_abb7 // #LOC_IFS_Resources_abb7 = HTP
+	displayName = #LOC_IFS_Resources_displayName7 // #LOC_IFS_Resources_displayName7 = Hydrogen Peroxide
     	density = 0.001431
     	unitCost = 2.1465
     	hsp = 2721
@@ -398,7 +398,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
 RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
 {
     	name = Kerosene
-	displayName = Kerosene
+	displayName = #LOC_CRP_Kerosene_DisplayName // #LOC_CRP_Kerosene_DisplayName = Kerosene
     	density = 0.00082
     	unitCost = 0.041
     	hsp = 2010 // specific heat capacity (kJ/tonne-K as units)


### PR DESCRIPTION
Changes for localization. Hydrogen peroxide does not have a name (only an abbreviation) in the original file "CRP", so it is presented separately. Kerosene has a link to its original in "CRP."