### PR TITLE
Adjust fuel-oxidiser mixture ratios in tanks and engines

### DIFF
--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT105HydroLOx.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT105HydroLOx.cfg
@@ -1,6 +1,6 @@
 // Resource setup for InterstellarFuelSwitch CDT-series tanks
 @PART[CDT2???]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSCDT105]{
-	%IFSVHydroLOxLqdHydrogen = 0.8
+	%IFSVHydroLOxLqdHydrogen = 0.78
 	@IFSVHydroLOxLqdHydrogen *= #$IFSV1$
 	%IFSVHydroLOxLqdOxygen = #$IFSV1$
 	@IFSVHydroLOxLqdOxygen -= #$IFSVHydroLOxLqdHydrogen$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT110MethaLOx.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT110MethaLOx.cfg
@@ -1,6 +1,6 @@
 // Resource setup for InterstellarFuelSwitch CDT-series tanks
 @PART[CDT2???]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSCDT110]{
-	%IFSVMethaLOxLqdMethane = 0.557
+	%IFSVMethaLOxLqdMethane = 0.445
 	@IFSVMethaLOxLqdMethane *= #$IFSV1$
 	%IFSVMethaLOxLqdOxygen = #$IFSV1$
 	@IFSVMethaLOxLqdOxygen -= #$IFSVMethaLOxLqdMethane$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT120KeroLOx.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSCDT120KeroLOx.cfg
@@ -1,6 +1,6 @@
 // Resource setup for InterstellarFuelSwitch CDT-series tanks
 @PART[CDT2???]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSCDT120]{
-	%IFSVKeroLOxKerosene = 0.4564596
+	%IFSVKeroLOxKerosene = 0.34
 	@IFSVKeroLOxKerosene *= #$IFSV1$
 	%IFSVKeroLOxLqdOxygen = #$IFSV1$
 	@IFSVKeroLOxLqdOxygen -= #$IFSVKeroLOxKerosene$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSWRAPPER105HydroLOx.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSWRAPPER105HydroLOx.cfg
@@ -1,6 +1,6 @@
 // Resource setup for InterstellarFuelSwitch WRAPPER-series tanks
 @PART[IfsWrapper*]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSWRAPPER105]{
-	%IFSVHydroLOxLqdHydrogen = 0.8
+	%IFSVHydroLOxLqdHydrogen = 0.78
 	@IFSVHydroLOxLqdHydrogen *= #$IFSV1$
 	%IFSVHydroLOxLqdOxygen = #$IFSV1$
 	@IFSVHydroLOxLqdOxygen -= #$IFSVHydroLOxLqdHydrogen$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSWRAPPER110MethaLOx.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IFSWRAPPER110MethaLOx.cfg
@@ -1,6 +1,6 @@
 // Resource setup for InterstellarFuelSwitch WRAPPER-series tanks
 @PART[IfsWrapper*]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSWRAPPER110]{
-	%IFSVMethaLOxLqdMethane = 0.557
+	%IFSVMethaLOxLqdMethane = 0.445
 	@IFSVMethaLOxLqdMethane *= #$IFSV1$
 	%IFSVMethaLOxLqdOxygen = #$IFSV1$
 	@IFSVMethaLOxLqdOxygen -= #$IFSVMethaLOxLqdMethane$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
@@ -16,7 +16,7 @@
 	@cryoPower /= 800
 
 	%MethaneMixOX = #$onlyLH2$
-	@MethaneMixOX *= 0.443
+	@MethaneMixOX *= 0.555
 	%MethaneMixLH2 = #$onlyLH2$
 	@MethaneMixLH2 -= #$MethaneMixOX$
 
@@ -26,7 +26,7 @@
 	@LANTRmixLH2 -= #$LANTRmixOX$
 
 	%LH2OMixLH2 = #$onlyLH2$
-	@LH2OMixLH2 *= 0.9375
+	@LH2OMixLH2 *= 0.78
 	%LH2OMixOX = #$onlyLH2$
 	@LH2OMixOX -= #$LH2OMixLH2$
 	

--- a/GameData/WarpPlugin/Parts/Engines/MethaneEngine/part.cfg
+++ b/GameData/WarpPlugin/Parts/Engines/MethaneEngine/part.cfg
@@ -172,13 +172,13 @@ MODULE
 	PROPELLANT
 	{
 		name = LqdHydrogen
-        	ratio = 0.8
+		ratio = 0.78
 		DrawGauge = True
 	}
 	PROPELLANT
 	{
 		name = LqdOxygen
-		ratio = 0.2
+		ratio = 0.22
 		DrawGauge = True
 	}
 	atmosphereCurve
@@ -207,13 +207,13 @@ MODULE
 	PROPELLANT
 	{
 		name = LqdMethane
-		ratio = 0.557
+		ratio = 0.445
 		DrawGauge = True
 	}
 	PROPELLANT
 	{
 		name = LqdOxygen
-		ratio = 0.443
+		ratio = 0.555
 		DrawGauge = True
 	}
 	atmosphereCurve

--- a/GameData/WarpPlugin/Resources/EnginePropellants.cfg
+++ b/GameData/WarpPlugin/Resources/EnginePropellants.cfg
@@ -313,13 +313,13 @@ BASIC_NTR_PROPELLANT
 	PROPELLANT
 	{
 		name = LqdHydrogen
-        	ratio = 0.80
+		ratio = 0.78
 		DrawGauge = True
 	}
 	PROPELLANT
 	{
 		name = LqdOxygen
-		ratio = 0.20
+		ratio = 0.22
 		DrawGauge = False
 	}
 }
@@ -340,7 +340,7 @@ BASIC_NTR_PROPELLANT
 	PROPELLANT
 	{
 		name = LqdHydrogen
-        	ratio = 1.5
+		ratio = 1.5
 		DrawGauge = True
 	}
 	PROPELLANT
@@ -373,7 +373,7 @@ BASIC_NTR_PROPELLANT
 	PROPELLANT
 	{
 		name = LqdHydrogen
-        	ratio = 1.5
+		ratio = 1.5
 		DrawGauge = True
 	}
 }
@@ -481,13 +481,13 @@ BASIC_NTR_PROPELLANT
 	PROPELLANT
 	{
 		name = LqdMethane
-        	ratio = 0.557
+        	ratio = 0.445
 		DrawGauge = True
 	}
 	PROPELLANT
 	{
 		name = LqdOxygen
-        	ratio = 0.443
+        	ratio = 0.555
 		DrawGauge = false
 	}
 }


### PR DESCRIPTION
I calculated this using mixture data from [wikipedia](https://en.wikipedia.org/wiki/Liquid_rocket_propellant) and densities from [CommonResources.cfg](https://github.com/sswelm/KSP-Interstellar-Extended/blob/84d5e5b80e3e675448b55b53282d9804b2cac625/GameData/CommunityResourcePack/CommonResources.cfg).
Closes #534 