### PR TITLE
Fix syntax error in KSP-Interstellar-Extended.version

### DIFF
--- a/GameData/WarpPlugin/Plugins/KSP-Interstellar-Extended.version
+++ b/GameData/WarpPlugin/Plugins/KSP-Interstellar-Extended.version
@@ -9,14 +9,14 @@
         "PATCH":0,
         "BUILD":1
     },
-	"KSP_VERSION_MIN":{
-		"MAJOR":1,
-		"MINOR":4,
-		"PATCH":5
-		}
-	"KSP_VERSION_MAX":{
-		"MAJOR":1,
-		"MINOR":7,
-		"PATCH":3
-		}
+    "KSP_VERSION_MIN":{
+        "MAJOR":1,
+        "MINOR":4,
+        "PATCH":5
+    },
+    "KSP_VERSION_MAX":{
+        "MAJOR":1,
+        "MINOR":7,
+        "PATCH":3
+    }
 }


### PR DESCRIPTION
## Problem
The 1.25.0.1 .version file has a comma missing.
It seems you fixed it out of tree for 1.25.0.5, however CKAN can't index the "old" version with the syntax error.

## Changes
Added a missing comma, also changed tabs to spaces to make it consistent.

You'll have to reupload / change out the uploaded zip for 1.25.0.1 with the fixed .version file so CKAN can index it.