### PR TITLE
Fix Configurable Containers integration

### DIFF
--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuel.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuel.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers]:FOR[InterstellarFuelSwitch]
+@PART[*]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers/Parts]:FOR[InterstellarFuelSwitch]
 {
 	%totalCap = #$RESOURCE[LiquidFuel]/maxAmount$
 

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers]:FOR[InterstellarFuelSwitch]
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers/Parts]:FOR[InterstellarFuelSwitch]
 {
 	%LF = #$RESOURCE[LiquidFuel]/maxAmount$
 	%OX = #$RESOURCE[Oxidizer]/maxAmount$

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationOxygen.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationOxygen.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@RESOURCE[Oxygen],!RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers]:FOR[InterstellarFuelSwitch]
+@PART[*]:HAS[@RESOURCE[Oxygen],!RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers/Parts]:FOR[InterstellarFuelSwitch]
 {
 	%totalCap = #$RESOURCE[Oxygen]/maxAmount$
 

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationXenon.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationXenon.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@RESOURCE[XenonGas],!RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers]:FOR[InterstellarFuelSwitch]
+@PART[*]:HAS[@RESOURCE[XenonGas],!RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!RESOURCE[MonoPropellant],!MODULE[ModuleTankManager],!MODULE[InterstellarFuelSwitch],!MODULE[FSfuelSwitch],!MODULE[ModuleB9PartSwitch],!MODULE[ModuleEnginesFX],!MODULE[ModuleEngines]]:NEEDS[InterstellarFuelSwitch&!ModularFuelTanks&!RealFuels&!ConfigurableContainers/Parts]:FOR[InterstellarFuelSwitch]
 {
 	%totalCap = #$RESOURCE[XenonGas]/maxAmount$
 


### PR DESCRIPTION
Properly apply IFS patches on a KSP installation that contains Configurable Containers Core only (not the main mod).

Fix is done as suggested by Aelfhe1m and allista in these [comments](https://forum.kerbalspaceprogram.com/index.php?/topic/150104-17-configurable-containers/page/23/&tab=comments#comment-3722271), using the presence of ConfigurableContainers/Parts sub-directory to distinguish between Configurable Containers Core (no Parts sub-directory) and Configurable Containers 'Full'.

I've checked and it works as expected (on my machine ^^)! 

Please let me know if I need to perform other checks or better describe of the issue (maybe I should raise an issue here on GitHub do document this?).