### PR TITLE
Misplaced symbol (probably pasted by accident?).

### DIFF
--- a/GameData/WarpPlugin/Patches/TweakscaleConfigs.cfg
+++ b/GameData/WarpPlugin/Patches/TweakscaleConfigs.cfg
@@ -834,8 +834,6 @@ TWEAKSCALEEXPONENTS
         undeployedHabitatSurface = 2
 }
 
-FNHabitat
-
 SCALETYPE
 {
 	name = surface_flat  


### PR DESCRIPTION
Found this by accident, a string lose on the config file. Interestingly, no error is issued by KSP - I really found this by accident, while trying to diagnose something else.