### PR TITLE
IFS: LiteFuels: change integration unlock tech and add tank configs

### DIFF
--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuel.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuel.cfg
@@ -15,7 +15,7 @@
 		resourceGui = #autoLOC_500999;#autoLOC_501000;#autoLOC_501002;#LOC_IFS_LqdHydrogen_GUIName;#LOC_IFS_LqdMethane_GUIName
 		resourceNames = LiquidFuel;Oxidizer;MonoPropellant;LqdHydrogen;LqdMethane
 		resourceAmounts = #$../totalCap$;$../totalCap$;$../totalCap$;$../onlyLH2$;$../onlyLH2$
-		tankTechReq = start;start;advFuelSystems;advFuelSystems;highPerformanceFuelSystems
+		tankTechReq = start;start;advFuelSystems;advRocketry;advRocketry
 		tankResourceMassDivider = 8;8;6.66666666666;5.5;8
 		adaptiveTankSelection = false
 		orderBySwitchName = true
@@ -30,7 +30,7 @@
 		resourceGui = #autoLOC_500999;#autoLOC_501000;#autoLOC_501002;#LOC_IFS_LqdHydrogen_GUIName;#LOC_IFS_LqdNitrogen_GUIName;#LOC_IFS_LqdArgon_GUIName;#LOC_IFS_LqdMethane_GUIName;#LOC_IFS_LqdAmmonia_GUIName;#LOC_IFS_Hydrazine_GUIName;#LOC_IFS_LqdCO2_GUIName;#LOC_IFS_HTP_Abbreviation
 		resourceNames = LiquidFuel;Oxidizer;MonoPropellant;LqdHydrogen;LqdNitrogen;LqdArgon;LqdMethane;LqdAmmonia;Hydrazine;LqdCO2;HTP
 		resourceAmounts = #$../totalCap$;$../totalCap$;$../totalCap$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$
-		tankTechReq = start;start;advFuelSystems;advFuelSystems;largeVolumeContainment;largeVolumeContainment;highPerformanceFuelSystems;highPerformanceFuelSystems;specializedFuelStorage;largeVolumeContainment;specializedFuelStorage
+		tankTechReq = start;start;advFuelSystems;advRocketry;largeVolumeContainment;largeVolumeContainment;advRocketry;highPerformanceFuelSystems;advRocketry;largeVolumeContainment;specializedFuelStorage
 		tankResourceMassDivider = 8;8;6.66666666666;5.5;8;8;8;8;8;8;8
 		adaptiveTankSelection = false
 		orderBySwitchName = true

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/IntegrationLiquidFuelOxidizer.cfg
@@ -53,7 +53,7 @@
 		resourceGui = #LOC_IFS_LiquidFuel+Oxidizer_GUIName;#autoLOC_502032;#autoLOC_501000;#autoLOC_501002;#LOC_IFS_LqdHydrogen_GUIName;#LOC_IFS_Hydrolox_GUIName;#LOC_IFS_Hydrogen+Oxidizer_GUIName;#LOC_IFS_Methalox_GUIName;#LOC_IFS_LqdNitrogen_GUIName;#LOC_IFS_LqdArgon_GUIName;#LOC_IFS_LqdMethane_GUIName;#LOC_IFS_LqdAmmonia_GUIName;#LOC_IFS_Hydrazine_GUIName;#LOC_IFS_LqdCO2_GUIName;#LOC_IFS_HTP_GUIName
 		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;Oxidizer;MonoPropellant;LqdHydrogen;LqdHydrogen,LqdOxygen;LqdHydrogen,Oxidizer;LqdMethane,LqdOxygen;LqdNitrogen;LqdArgon;LqdMethane;LqdAmmonia;Hydrazine;LqdCO2;HTP
 		resourceAmounts = #$../LF$,$../OX$;$../totalCap$;$../totalCap$;$../totalCap$;$../pureLH2$;$../LANTRmixLH2$,$../LANTRmixOX$;$../LH2OMixLH2$,$../LH2OMixOX$;$../MethaneMixLH2$,$../MethaneMixOX$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$;$../onlyLH2$
-		tankTechReq = start;start;start;advFuelSystems;advFuelSystems;advFuelSystems;advFuelSystems;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment;largeVolumeContainment
+		tankTechReq = start;start;start;advFuelSystems;advFuelSystems;advFuelSystems;advFuelSystems;advRocketry;largeVolumeContainment;largeVolumeContainment;advRocketry;largeVolumeContainment;advRocketry;largeVolumeContainment;largeVolumeContainment
 		tankMass = 0;0;0;0;0;0;0;0;0;0;0;0;0;0;0
 		tankResourceMassDivider = 8;8;8;6.66666666666;8;12;12;16;18;18;16;18;18;18;18
 		adaptiveTankSelection = false
@@ -61,6 +61,28 @@
 		displayTankCost = true
 		hasGUI = true
 	}
+
+  @MODULE[InterstellarFuelSwitch] {
+    %MixHyF = 0.51
+    @MixHyF *= #$../onlyLH2$
+    %MixHyO = #$../onlyLH2$
+    @MixHyO -= #$MixHyF$
+    %MixKeF = 0.4564596
+    @MixKeF *= #$../onlyLH2$
+    %MixKeO = #$../onlyLH2$
+    @MixKeO -= #$MixKeF$
+    @tankSwitchNames = #$tankSwitchNames$;HydraNitro;DNTO;Kerolox;Kerosene
+    @resourceGui = #$resourceGui$;HydraNitro;DNTO;Kerolox;Kerosene
+    @resourceNames = #$resourceNames$;Hydrazine,NTO;NTO;Kerosene,LqdOxygen;Kerosene
+    @resourceAmounts = #$resourceAmounts$;$MixHyF$,$MixHyO$;$../onlyLH2$;$MixKeF$,$MixKeO$;$../onlyLH2$
+    @tankMass = #$tankMass$;0;0;0;0
+    @tankResourceMassDivider = #$tankResourceMassDivider$;18;18;18;18
+    @tankTechReq = #$tankTechReq$;start;start;start
+    -MixHyF = 0
+    -MixHyO = 0
+    -MixKeF = 0
+    -MixKeO = 0
+  }
 
     	MODULE
     	{

--- a/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/LiteFuels.cfg
+++ b/GameData/InterstellarFuelSwitch/PatchManager/ActiveMMPatches/LiteFuels.cfg
@@ -1,0 +1,121 @@
+
+// Resource setup for InterstellarFuelSwitch CDT-series tanks
+@PART[CDT2???]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSCDT130]{
+  @MODULE[InterstellarMeshSwitch]:HAS[#moduleID[IFSCDTmeshSwitcher]]
+  {
+    @tankSwitchNames = #$tankSwitchNames$;HydraNitro;DNTO
+    @objectDisplayNames = #$objectDisplayNames$;Hydrazine + DNTO;DNTO
+    @objects = #$objects$;HydraNitro;DNTO
+    @indexNames = #$indexNames$;HydraNitro;DNTO
+    @fuelTankSetups = #$fuelTankSetups$;HydraNitro;DNTO
+    @fuelTankCounter += 1
+  }
+  @MODULE[InterstellarFuelSwitch]:HAS[#moduleID[IFSCDTfuelSwitcher]]
+  {
+    %MixHyF = 0.51
+    @MixHyF *= #$../IFSV1$
+    %MixHyO = #$../IFSV1$
+    @MixHyO -= #$MixHyF$
+    @tankSwitchNames = #$tankSwitchNames$;HydraNitro;DNTO
+    @resourceNames = #$resourceNames$;Hydrazine,NTO;NTO
+    @resourceAmounts = #$resourceAmounts$;$MixHyF$,$MixHyO$;$../IFSV1$
+    //@tankCost = #$tankCost$;0;0
+    @tankMass = #$tankMass$;$../IFSMtank$;$../IFSMtank$
+    @tankResourceMassDivider = #$tankResourceMassDivider$;20;20
+    -MixHyF = 0
+    -MixHyO = 0
+  }
+}
+
+// Resource setup for InterstellarFuelSwitch WRAPPER-series tanks
+@PART[IfsWrapper*]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSWRAPPER130]{
+  @MODULE[InterstellarFuelSwitch]:HAS[#moduleID[IFSWRAPPERfuelSwitcher]]
+  {
+    %MixHyF = 0.51
+    @MixHyF *= #$../IFSV1$
+    %MixHyO = #$../IFSV1$
+    @MixHyO -= #$MixHyF$
+    @tankSwitchNames = #$tankSwitchNames$;HydraNitro;DNTO
+    @resourceGui = #$resourceGui$;HydraNitro;DNTO
+    @resourceNames = #$resourceNames$;Hydrazine,NTO;NTO
+    @resourceAmounts = #$resourceAmounts$;$MixHyF$,$MixHyO$;$../IFSV1$
+    //@tankCost = #$tankCost$;0;0
+    @tankMass = #$tankMass$;$../IFSMtank$;$../IFSMtank$
+    @tankResourceMassDivider = #$tankResourceMassDivider$;20;20
+    -MixHyF = 0
+    -MixHyO = 0
+  }
+}
+
+// Resource setup for InterstellarFuelSwitch CT-series tanks
+@PART[CT250?]:HAS[@RESOURCE[LiterVolume]]:FOR[IFSCT156]{
+  @MODULE[InterstellarMeshSwitch]:HAS[#moduleID[IFSCTmeshSwitcher]]
+  {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @objectDisplayNames = #$objectDisplayNames$;DNTO
+    @objects = #$objects$;14N2O4,l
+    @indexNames = #$indexNames$;DNTO
+    @fuelTankSetups = #$fuelTankSetups$;DNTO
+    @fuelTankCounter += 1
+    @moduleIDCounter += 2048
+  }
+  @MODULE[InterstellarFuelSwitch]:HAS[#moduleID[IFSCTfuelSwitcher]]
+  {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @resourceNames = #$resourceNames$;NTO
+    @resourceAmounts = #$resourceAmounts$;$../IFSV1$
+    @tankCost = #$tankCost$;0
+    //@tankMass = #$tankMass$;$../mass$
+    @moduleIDCounter += 2048
+  }
+}
+
+// Resource setup for Integration tanks
+// -> moved to IntegrationLiquidFuel.cfg
+
+// Resource setup for ifsBigSphereTank
+@PART[ifsBigSphereTank]:NEEDS[!ModularFuelTanks&!RealFuels&!ConfigurableContainers]
+{
+  @MODULE[InterstellarFuelSwitch] {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @resourceGui = #$resourceGui$;DNTO
+    @resourceNames = #$resourceNames$;NTO
+    @resourceAmounts = #$resourceAmounts$;474000
+    @tankCost = #$tankCost$;0
+  }
+}
+// Resource setup for KspiInflatableLiquidTank
+@PART[KspiInflatableLiquidTank]:NEEDS[!ModularFuelTanks&!RealFuels&!ConfigurableContainers]
+{
+  @MODULE[InterstellarFuelSwitch] {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @resourceGui = #$resourceGui$;DNTO
+    @resourceNames = #$resourceNames$;NTO
+    @resourceAmounts = #$resourceAmounts$;140000
+    @tankCost = #$tankCost$;0
+  }
+}
+// Resource setup for Radial InterstellarSphereTank
+@PART[InterstellarSphereTank]:NEEDS[!ModularFuelTanks&!RealFuels&!ConfigurableContainers]
+{
+  @MODULE[InterstellarFuelSwitch] {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @resourceGui = #$resourceGui$;DNTO
+    @resourceNames = #$resourceNames$;NTO
+    @resourceAmounts = #$resourceAmounts$;8000
+  }
+}
+// Resource setup for kspiSphericalTank(s)
+@PART[kspiSphericalTank*]:NEEDS[!ModularFuelTanks&!RealFuels&!ConfigurableContainers]
+{
+  @MODULE[InterstellarFuelSwitch] {
+    @tankSwitchNames = #$tankSwitchNames$;DNTO
+    @resourceGui = #$resourceGui$;DNTO
+    @resourceNames = #$resourceNames$;NTO
+    @resourceAmounts = #$resourceAmounts$;$../RESOURCE[LqdHydrogen]/maxAmount$
+    @tankCost = #$tankCost$;0
+  }
+}
+
+//TODO: integration monoprop tanks
+//TODO: BOILOFF??


### PR DESCRIPTION
Decreased unlock tech for Kerolox and Methalox in stock tanks to make starting with [LiteFuels](https://spacedock.info/mod/2391/LiteFuels) possible.
Added configs for normal IFS tanks to contain LiteFuels mixtures.