### PR TITLE
Krump's EPA fast tracks new rules for businesses

### DIFF
--- a/FNPlugin/Propulsion/InterstellarMagneticNozzleControllerFX.cs
+++ b/FNPlugin/Propulsion/InterstellarMagneticNozzleControllerFX.cs
@@ -571,6 +571,9 @@ namespace FNPlugin
 
         private bool AllowedExhaust()
         {
+            if (CheatOptions.IgnoreAgencyMindsetOnContracts)
+                return true;
+
             var homeworld = FlightGlobals.GetHomeBody();
             var toHomeworld = vessel.CoMD - homeworld.position;
             var distanceToSurfaceHomeworld = toHomeworld.magnitude - homeworld.Radius;


### PR DESCRIPTION
Krump's Head of the EPA has decided that environmental concerns are bad for their donors^W^Wbig business^W^Wjob creators, and are getting in the way of polluting Kamerica, and poisoning the water systems.