### PR TITLE
Fix mining location

### DIFF
--- a/FNPlugin/Collectors/UniversalCrustExtractor.cs
+++ b/FNPlugin/Collectors/UniversalCrustExtractor.cs
@@ -687,8 +687,8 @@ namespace FNPlugin.Collectors
                         ResourceType = HarvestTypes.Planetary,
                         ResourceName = currentResource.ResourceName,
                         BodyId = FlightGlobals.currentMainBody.flightGlobalsIndex,
-                        Latitude = FlightGlobals.ship_latitude,
-                        Longitude = FlightGlobals.ship_longitude,
+                        Latitude = this.vessel.latitude,
+                        Longitude = this.vessel.longitude,
                         CheckForLock = false
                     });
 


### PR DESCRIPTION
Use the current parts vessels location, instead of the global active vessels location for mining resources.

closes #597