### PR TITLE
Game state race conditions

### DIFF
--- a/FNPlugin/Science/ComputerCore.cs
+++ b/FNPlugin/Science/ComputerCore.cs
@@ -29,8 +29,6 @@ namespace FNPlugin
         public double science_to_add;
         [KSPField(isPersistant = true)]
         public bool coreInit = false;
-        //[KSPField]
-        //public double alternatorPower = 0.001;
         [KSPField]
         public string upgradeTechReq = null;
         [KSPField]
@@ -168,8 +166,6 @@ namespace FNPlugin
         {
             base.OnFixedUpdate();
 
-            //
-
             if (isupgraded && IsEnabled)
             {
                 var power_returned = CheatOptions.InfiniteElectricity
@@ -181,7 +177,7 @@ namespace FNPlugin
 
                 if (IsPowered)
                 {
-                    HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().requireSignalForControl = false;
+                    moduleCommand.requiresTelemetry = false;
 
                     double altitude_multiplier = Math.Max(vessel.altitude / vessel.mainBody.Radius, 1);
 
@@ -194,9 +190,8 @@ namespace FNPlugin
                 }
                 else
                 {
-                    HighLogic.CurrentGame.Parameters.CustomParams<CommNetParams>().requireSignalForControl = true;
+                    moduleCommand.requiresTelemetry = true;
 
-                    // return any unused power
                     part.RequestResource(ResourceManager.FNRESOURCE_MEGAJOULES, -power_returned * TimeWarp.fixedDeltaTime);
                 }
             }
@@ -213,9 +208,6 @@ namespace FNPlugin
 
         public override void OnFixedUpdateResourceSuppliable(double fixedDeltaTime)
         {
-            //supplyFNResourcePerSecondWithMax(alternatorPower, alternatorPower, ResourceManager.FNRESOURCE_MEGAJOULES);
-
-            //part.temperature = part.temperature + (TimeWarp.fixedDeltaTime * 1000 * alternatorPower / (part.thermalMass * 0.8));
         }
 
         protected override bool generateScienceData()

--- a/FNPlugin/Science/ComputerCore.cs
+++ b/FNPlugin/Science/ComputerCore.cs
@@ -177,7 +177,14 @@ namespace FNPlugin
 
                 if (IsPowered)
                 {
-                    moduleCommand.requiresTelemetry = false;
+                    if(moduleCommand != null)
+                        moduleCommand.requiresTelemetry = false;
+
+                    if (part.vessel != null && part.vessel.connection != null && part.vessel.connection.Comm != null)
+                    {
+                        part.vessel.connection.Comm.isHome = true;
+                        part.vessel.connection.Comm.isControlSource = true;
+                    }
 
                     double altitude_multiplier = Math.Max(vessel.altitude / vessel.mainBody.Radius, 1);
 
@@ -190,7 +197,14 @@ namespace FNPlugin
                 }
                 else
                 {
-                    moduleCommand.requiresTelemetry = true;
+                    if(moduleCommand != null)
+                        moduleCommand.requiresTelemetry = true;
+
+                    if (part.vessel != null && part.vessel.connection != null && part.vessel.connection.Comm != null)
+                    {
+                        part.vessel.connection.Comm.isHome = false;
+                        part.vessel.connection.Comm.isControlSource = false;
+                    }
 
                     part.RequestResource(ResourceManager.FNRESOURCE_MEGAJOULES, -power_returned * TimeWarp.fixedDeltaTime);
                 }


### PR DESCRIPTION
Modifying the game state is full of race conditions (think of ships as threads, and the user as another thread) and leaving the game state in an unexpected state (people may be playing with require commnet for control = false, when they expect = true, and have set it to true).

Did some testing, these changes looks like it works as expected.

Will be able to control a near by ship with the probe control port as well (tested both multi hop and single hop probe controls). (My test case had a RA-100 relay antenna on it, in case that's needed to control near by ships).