### PR TITLE
Fix power requirements for Universal Drill

### DIFF
--- a/FNPlugin/Collectors/UniversalCrustExtractor.cs
+++ b/FNPlugin/Collectors/UniversalCrustExtractor.cs
@@ -60,7 +60,7 @@ namespace FNPlugin.Collectors
 
         private int powerCountdown;
         private int powerCountdownMax = 90;
-        private double minimumPowerNeeded = 15;
+        private const double minimumPowerNeeded = 0.15;
 
         // GUI elements declaration
         private Rect _window_position = new Rect(50, 50, labelWidth + valueWidth * 5, 150);

--- a/FNPlugin/External/FNHabitat.cs
+++ b/FNPlugin/External/FNHabitat.cs
@@ -858,7 +858,14 @@ namespace FNPlugin
 
         public void AssumeDragCubePosition(string name)
         {
-            var anim = part.FindModelAnimators(deployAnimationName)[0];
+            var anims = part.FindModelAnimators(deployAnimationName);
+            if (anims == null || anims.Length < 1)
+            {
+                enabled = false;
+                return;
+            }
+
+            var anim = anims[0];
             if (anim == null)
             {
                 enabled = false;


### PR DESCRIPTION
Fix an off-by-100x percentage error which made universal drills think that they never had enough power to run. Fix an exception when calculating drag cubes for the IXS command capsule.