### PR TITLE
Near Future reactors fix

### DIFF
--- a/FNPlugin/Wasteheat/FNFissionGeneratorAdapter.cs
+++ b/FNPlugin/Wasteheat/FNFissionGeneratorAdapter.cs
@@ -1,7 +1,5 @@
 ﻿using FNPlugin.Power;
 using FNPlugin.Wasteheat;
-using System;
-using UnityEngine;
 
 namespace FNPlugin
 {
@@ -13,85 +11,54 @@ namespace FNPlugin
         [KSPField(isPersistant = false, guiActive = true, guiName = "#LOC_KSPIE_NFFAdapter_Efficiency")]//Efficiency
         public string OverallEfficiency;
 
+        private BaseField fieldGenerated;
+        private BaseField fieldMax;
         private PartModule moduleGenerator;
-        private BaseField _field_status;
-        private BaseField _field_generated;
-        private BaseField _field_addedToTanks;
-        private BaseField _field_max;
 
         private bool active = false;
         private ResourceBuffers resourceBuffers;
 
         public override void OnStart(StartState state)
         {
-            try
-            {
-                if (state == StartState.Editor) return;
+            resources_to_supply = new string[] { ResourceManager.FNRESOURCE_MEGAJOULES, ResourceManager.FNRESOURCE_WASTEHEAT };
+            base.OnStart(state);
 
+            if (state != StartState.Editor)
+            {
                 if (part.Modules.Contains("FissionGenerator"))
                 {
                     moduleGenerator = part.Modules["FissionGenerator"];
-                    _field_status = moduleGenerator.Fields["Status"];
-                    _field_generated = moduleGenerator.Fields["CurrentGeneration"];
-                    _field_addedToTanks = moduleGenerator.Fields["AddedToFuelTanks"];
-                    _field_max = moduleGenerator.Fields["PowerGeneration"];
+                    fieldGenerated = moduleGenerator.Fields["CurrentGeneration"];
+                    fieldMax = moduleGenerator.Fields["PowerGeneration"];
                 }
 
                 if (moduleGenerator == null) return;
 
                 OverallEfficiency = "10%";
 
-                String[] resources_to_supply = { ResourceManager.FNRESOURCE_MEGAJOULES, ResourceManager.FNRESOURCE_WASTEHEAT };
-                this.resources_to_supply = resources_to_supply;
-                base.OnStart(state);
-
                 resourceBuffers = new ResourceBuffers();
                 resourceBuffers.AddConfiguration(new ResourceBuffers.MaxAmountConfig(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, 50));
                 resourceBuffers.AddConfiguration(new WasteHeatBufferConfig(1, 2.0e+5, true));
-                resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_WASTEHEAT, (double)(decimal)this.part.mass);
-                resourceBuffers.Init(this.part);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNFissionGeneratorAdapter.OnStart " + e.Message);
-                throw;
+                resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_WASTEHEAT, part.mass);
+                resourceBuffers.Init(part);
             }
         }
 
         public override void OnFixedUpdate()
         {
-            try
+            if (HighLogic.LoadedSceneIsFlight && moduleGenerator != null)
             {
-                if (!HighLogic.LoadedSceneIsFlight) return;
-
-                if (moduleGenerator == null) return;
-
                 active = true;
                 base.OnFixedUpdate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNFissionGeneratorAdapter.OnFixedUpdate " + e.Message);
-                throw;
             }
         }
 
 
         public void FixedUpdate()
         {
-            try
+            if (HighLogic.LoadedSceneIsFlight && moduleGenerator != null && !active)
             {
-                if (!HighLogic.LoadedSceneIsFlight) return;
-
-                if (moduleGenerator == null) return;
-
-                if (!active)
-                    base.OnFixedUpdate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNFissionGeneratorAdapter.OnFixedUpdate " + e.Message);
-                throw;
+                base.OnFixedUpdate();
             }
         }
 
@@ -108,36 +75,19 @@ namespace FNPlugin
 
         public override void OnFixedUpdateResourceSuppliable(double fixedDeltaTime)
         {
-            try
-            {
-                if (moduleGenerator == null) return;
-                if (_field_status == null) return;
-                if (_field_generated == null) return;
+            if (moduleGenerator == null || fieldGenerated == null) return;
 
-                bool status = _field_status.GetValue<bool>(moduleGenerator);
+            float generatorRate = fieldGenerated.GetValue<float>(moduleGenerator);
+            float generatorMax = fieldMax.GetValue<float>(moduleGenerator);
 
-                float generatorRate = status ? _field_generated.GetValue<float>(moduleGenerator) : 0;
-                float generatorMax = _field_max.GetValue<float>(moduleGenerator);
+            // extract power otherwise we end up with double power
+            resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_WASTEHEAT, part.mass);
+            resourceBuffers.UpdateBuffers();
 
-                // extract power otherwise we end up with double power
-                if (_field_addedToTanks != null)
-                {
-                    part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, (double)_field_addedToTanks.GetValue<float>(moduleGenerator));
-                }
+            megaJouleGeneratorPowerSupply = supplyFNResourcePerSecondWithMax(generatorRate / 1000, generatorMax / 1000, ResourceManager.FNRESOURCE_MEGAJOULES);
 
-                resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_WASTEHEAT, this.part.mass);
-                resourceBuffers.UpdateBuffers();
-
-                megaJouleGeneratorPowerSupply = supplyFNResourcePerSecondWithMax(generatorRate / 1000, generatorMax / 1000, ResourceManager.FNRESOURCE_MEGAJOULES);
-
-                if (!CheatOptions.IgnoreMaxTemperature)
-                    supplyFNResourcePerSecond(generatorRate / 10000.0d, ResourceManager.FNRESOURCE_WASTEHEAT);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNFissionGeneratorAdapter.OnFixedUpdateResourceSuppliable " + e.Message);
-                throw;
-            }
+            if (!CheatOptions.IgnoreMaxTemperature)
+                supplyFNResourcePerSecond(generatorRate / 10000.0d, ResourceManager.FNRESOURCE_WASTEHEAT);
         }
     }
 }

--- a/GameData/WarpPlugin/Patches/NFTFissionReactors.cfg
+++ b/GameData/WarpPlugin/Patches/NFTFissionReactors.cfg
@@ -1,9 +1,0 @@
-@PART[*]:HAS[@MODULE[FissionGenerator]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
-{
-	@TechRequired = nuclearPower
-
-	MODULE
-	{
-		name = FNFissionGeneratorAdapter
-	}
-}

--- a/GameData/WarpPlugin/Patches/NFTFissionReactors.cfg
+++ b/GameData/WarpPlugin/Patches/NFTFissionReactors.cfg
@@ -1,0 +1,4 @@
+@PART[*]:HAS[@MODULE[FissionGenerator]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
+{
+	@description ^= :$: This reactor's compact size limits it to powering smaller electrical loads, so it cannot be used for beamed power or electrical engines requiring Megajoule energy.
+}


### PR DESCRIPTION
Get rid of the old, broken Interstellar Fission Reactor Adapter for Near Future Reactors as it duplicates power, generates MJ/WH that there is usually no storage for (so it gets voided depending on vessel construction) and is out of date with recent NF versions. Replace it with a warning that the NF reactors cannot be used for MJ loads.