### PR TITLE
Discussion - Active Cooling System

### DIFF
--- a/FNPlugin/Wasteheat/FNRadiator.cs
+++ b/FNPlugin/Wasteheat/FNRadiator.cs
@@ -103,6 +103,10 @@ namespace FNPlugin.Wasteheat
                 Fields[nameof(intakeLqdAmount)],
                 Fields[nameof(airCoolantTotal)],
                 Fields[nameof(waterCoolantTotal)],
+                Fields[nameof(steamCoolantTotal)],
+                Fields[nameof(airHeatTransferrable)],
+                Fields[nameof(waterHeatTransferrable)],
+                Fields[nameof(steamHeatTransferrable)],
             };
 
             var status = !debugFields[0].guiActive;
@@ -145,19 +149,6 @@ namespace FNPlugin.Wasteheat
             var powerAvail = consumeFNResourcePerSecond(powerNeeded, ResourceManager.FNRESOURCE_MEGAJOULES);
 
             return Math.Round(powerAvail / powerNeeded, 2);
-        }
-
-        private double PartSpeed()
-        {
-            // very rough approximation of the part rotation speed.
-            var rb = part.GetComponent<Rigidbody>();
-            if (rb == null)
-            {
-                // should not happen.
-                return 0;
-            }
-
-            return Math.Abs(rb.angularVelocity.magnitude);
         }
 
         public void FixedUpdate()
@@ -334,8 +325,8 @@ namespace FNPlugin.Wasteheat
 
             if (heatTransferred == 0) return;
 
-            if (intakeAtmAmount > 0) part.RequestResource(intakeAtmID, intakeAtmAmount * intakeReduction);
-            if (intakeLqdAmount > 0) part.RequestResource(intakeLqdID, intakeLqdAmount * intakeReduction);
+            if (intakeAtmAmount > 0) part.RequestResource(intakeAtmID, intakeAtmAmount * intakeReduction * fixedDeltaTime);
+            if (intakeLqdAmount > 0) part.RequestResource(intakeLqdID, intakeLqdAmount * intakeReduction * fixedDeltaTime);
         }
         public override int getPowerPriority()
         {

--- a/FNPlugin/Wasteheat/FNRadiator.cs
+++ b/FNPlugin/Wasteheat/FNRadiator.cs
@@ -21,6 +21,279 @@ namespace FNPlugin.Wasteheat
     class FlatFNRadiator : FNRadiator { }
 
     [KSPModule("Radiator")]
+    class ActiveRadiator3 : ResourceSuppliableModule
+    {
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Power Priority", guiFormat = "F0", guiUnits = ""), UI_FloatRange(stepIncrement = 1.0F, maxValue = 5F, minValue = 0F)]
+        public float powerPriority = 5;
+
+        [KSPField(isPersistant = true, guiActive = true, guiName = "Pumps"), UI_Toggle(disabledText = "#Off", enabledText = "On", affectSymCounterparts = UI_Scene.All)]
+        public bool pumpIsEnabled = true;
+
+        [KSPField]
+        public float surfaceArea = 100;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "intakeAtmSpecificHeatCapacity", guiFormat = "F0", guiUnits = "")]
+        public double intakeAtmSpecificHeatCapacity;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "intakeLqdSpecificHeatCapacity", guiFormat = "F0", guiUnits = "")]
+        public double intakeLqdSpecificHeatCapacity;
+
+        [KSPField(isPersistant = true, guiActive = false, guiName = "Pump Speed")]
+        public double pumpSpeed = 100;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Max Heat Transferrable", guiFormat = "F2", guiUnits = " K")]
+        public double heatTransferrable;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Max Heat Supply", guiFormat = "F2", guiUnits = " K")]
+        public double maxSupplyOfHeat;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Coolant Supply Used", guiFormat = "F2", guiUnits = "%")]
+        public double intakeReduction;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Intake ATM Amount", guiFormat = "F2", guiUnits = "")]
+        public double intakeAtmAmount;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Intake Lqd Amount", guiFormat = "F2", guiUnits = "")]
+        public double intakeLqdAmount;
+
+        [KSPField(isPersistant = false, guiActive = false, guiName = "Cool ants running amok", guiFormat = "F2", guiUnits = "")]
+        public double coolantTotal;
+
+        private const double pumpSpeedSqrt = 10;
+
+        private const double powerDrawInJoules = 1; // How much power needed to run fans / etc. in joules.
+
+        private const double airHeatTransferCoefficient = 0.0005; // 500W/m2/K, from FNRadiator.
+        private const double lqdHeatTransferCoefficient = 0.0007; // From AntaresMC
+
+        private int intakeLqdID;
+        private int intakeAtmID;
+        private double intakeLqdDensity;
+        private double intakeAtmDensity;
+
+        [KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "Show debug information", active = true)]
+        public void ToggleHeatPumpDebugAction()
+        {
+            BaseField[] debugFields = {
+                Fields[nameof(surfaceArea)],
+                Fields[nameof(intakeLqdSpecificHeatCapacity)],
+                Fields[nameof(intakeAtmSpecificHeatCapacity)],
+                Fields[nameof(pumpSpeed)],
+                Fields[nameof(heatTransferrable)],
+                Fields[nameof(maxSupplyOfHeat)],
+                Fields[nameof(intakeReduction)],
+                Fields[nameof(intakeAtmAmount)],
+                Fields[nameof(intakeLqdAmount)],
+            };
+
+            var status = !debugFields[0].guiActive;
+
+            foreach (var x in debugFields)
+            {
+                x.guiActive = status;
+            }
+
+        }
+
+        public override void OnStart(StartState state)
+        {
+            base.OnStart(state);
+
+            var intakeLqdDefinition = PartResourceLibrary.Instance.GetDefinition("IntakeLqd");
+            var intakeAirDefinition = PartResourceLibrary.Instance.GetDefinition("IntakeAir");
+            var intakeAtmDefinition = PartResourceLibrary.Instance.GetDefinition("IntakeAtm");
+
+            if (intakeLqdDefinition == null || intakeAirDefinition == null || intakeAtmDefinition == null)
+            {
+                Debug.Log("[ActiveCoolingSystemv3] Missing definitions :(");
+                return;
+            }
+
+            intakeLqdSpecificHeatCapacity = intakeLqdDefinition.specificHeatCapacity;
+            intakeAtmSpecificHeatCapacity = (intakeAtmDefinition.specificHeatCapacity == 0) ? intakeAirDefinition.specificHeatCapacity : intakeAtmDefinition.specificHeatCapacity;
+
+            intakeLqdID = intakeLqdDefinition.id;
+            intakeAtmID = intakeAtmDefinition.id;
+            intakeAtmDensity = intakeAtmDefinition.density;
+            intakeLqdDensity = intakeLqdDefinition.density;
+        }
+
+        private double drawPower()
+        {
+            // what does electricity look like, anyways?
+
+            var powerNeeded = powerDrawInJoules;
+            var powerAvail = consumeFNResourcePerSecond(powerNeeded, ResourceManager.FNRESOURCE_MEGAJOULES);
+
+            return Math.Round(powerAvail / powerNeeded, 2);
+        }
+
+        private double PartSpeed()
+        {
+            // very rough approximation of the part rotation speed.
+            var rb = part.GetComponent<Rigidbody>();
+            if (rb == null)
+            {
+                // should not happen.
+                return 0;
+            }
+
+            return Math.Abs(rb.angularVelocity.magnitude);
+        }
+
+        public void FixedUpdate()
+        {
+            if (!HighLogic.LoadedSceneIsFlight)
+                return;
+
+            intakeAtmAmount = intakeLqdAmount = 0;
+
+            if (null == vessel || null == part) return;
+            if (pumpIsEnabled == false) return;
+
+            var wasteheatManager = getManagerForVessel(ResourceManager.FNRESOURCE_WASTEHEAT);
+
+            /* reduce the efficiency of the transfer if there is not enough power to run at 100% */
+            var efficiency = drawPower();
+            if (efficiency == 0) return;
+
+            maxSupplyOfHeat = wasteheatManager.CurrentSurplus + wasteheatManager.GetResourceAvailability();
+            if (maxSupplyOfHeat == 0) return;
+
+            var fixedDeltaTime = (double)(decimal)TimeWarp.fixedDeltaTime;
+
+            part.GetConnectedResourceTotals(intakeAtmID, out intakeAtmAmount, out _);
+            part.GetConnectedResourceTotals(intakeLqdID, out intakeLqdAmount, out _);
+
+            // find our baseline of how cold the intake should be. PhysicsGlobals.SpaceTemperature is there in
+            // case of negative numbers later on, but that "should not happen".
+
+            double coldTemp = Math.Max(PhysicsGlobals.SpaceTemperature, Math.Min(part.skinTemperature, Math.Min(part.temperature, Math.Min(vessel.atmosphericTemperature, vessel.externalTemperature))));
+            double hotTemp = Math.Max(coldTemp + 0.1, coldTemp + (wasteheatManager.ResourceFillFraction * 3000));
+            double deltaT = hotTemp - coldTemp;
+
+            /*
+             * "Don't mind me, I'm just keeping your reactors cool!"
+             * 
+             * /\/\
+             *   \_\  _..._
+             *   (" )(_..._)
+             *    ^^  // \\
+             *   
+             * What kind of ant is good at adding things up? An accountant.
+             */
+
+            coolantTotal = 1 +
+                // how much potential energy can the air absorb
+                (intakeAtmDensity * intakeAtmAmount * intakeAtmSpecificHeatCapacity * 1000) +   // convert to liters
+                // how much potential energy can the water absorb
+                (intakeLqdDensity * intakeLqdAmount * intakeLqdSpecificHeatCapacity) +
+                // A rule of thumb suggests that a gas takes up about 1000 times the volume of a solid or liquid.
+                (intakeAtmDensity * (intakeLqdAmount * 1000) * intakeAtmSpecificHeatCapacity);
+
+            /*
+             *             "=.
+             *            "=. \
+             *               \ \
+             *            _,-=\/=._        _.-,_
+             *           /         \      /=-._ "-.
+             *          |=-./~\___/~\    /     `-._\
+             *          |   \o/   \o/   /         /
+             *           \_   `~~~;/    |         |
+             *             `~,._,-'    /          /
+             *                | |      =-._      /
+             *            _,-=/ \=-._     /|`-._/
+             *          //           \\   )\
+             *         /|             |)_.'/
+             *        //|             |\_."   _.-\
+             *       (|  \           /    _.`=    \
+             *       ||   ":_    _.;"_.-;"   _.-=.:
+             *    _-."/    / `-."\_."        =-_.;\
+             *   `-_./   /             _.-=.    / \\
+             *          |              =-_.;\ ."   \\
+             *          \                   \\/     \\
+             *          /\_                .'\\      \\
+             *         //  `=_         _.-"   \\      \\
+             *        //      `~-.=`"`'       ||      ||
+             *  LGB   ||    _.-_/|            ||      |\_.-_
+             *    _.-_/|   /_.-._/            |\_.-_  \_.-._\
+             *   /_.-._/                      \_.-._\
+             *   
+             *   "I expected cool ants. Where are the cool ants?!". That ant, probably. 
+             *   
+             *   What is the second biggest ant in the world? An elephant.
+             *   What ant is bigger than that? A giant.
+             */
+
+            // If water is present, it is more efficient to transfer the heat.
+            double transferCoefficient = (intakeLqdAmount > 0) ? lqdHeatTransferCoefficient : airHeatTransferCoefficient;
+
+            // account for the speed of the vessel, part, and the pumping speed.
+            // atmospheric density has already been accounted for by the pumping of
+            // resources.
+            double modifier = vessel.speed.Sqrt() + PartSpeed().Sqrt() + pumpSpeedSqrt;
+
+            // how much heat can we transfer in total
+            heatTransferrable = transferCoefficient * coolantTotal * efficiency * modifier * deltaT * surfaceArea;
+            if (heatTransferrable <= 0) return;
+
+            intakeReduction = 1;
+            var actuallyReduced = heatTransferrable;
+
+            if (maxSupplyOfHeat < heatTransferrable)
+            {
+                // To avoid the KSPIE screen saying that we're demanding far more WasteHeat than
+                // it can supply, we cap the max amount of heat here so it looks like 
+                // input == output on the screen.
+                actuallyReduced = maxSupplyOfHeat;
+
+                // if we could transfer more heat than exists, then we'll reduce the amount of
+                // coolant we use.
+                intakeReduction = Math.Max(0.10, maxSupplyOfHeat / heatTransferrable);
+
+
+                /*
+                 *  \       /
+                 *   \     /  
+                 *    \.-./ 
+                 *   (o\^/o)  _   _   _     __
+                 *    ./ \.\ ( )-( )-( ) .-'  '-.
+                 *     {-} \(//  ||   \\/ (   )) '-.
+                 *          //-__||__.-\\.       .-'
+                 *         (/    ()     \)'-._.-'
+                 *         ||    ||      \\
+                 * MJP     ('    ('       ')
+                 * 
+                 * How do you tell a girl ant and a boy ant apart?
+                 * If it sinks, it's a girl ant. If it floats, it's
+                 * a bouyant.
+                 */
+            }
+
+            var heatTransferred = consumeFNResourcePerSecond(actuallyReduced, ResourceManager.FNRESOURCE_WASTEHEAT);
+
+            if (heatTransferred == 0) return;
+
+            if (intakeAtmAmount > 0) part.RequestResource(intakeAtmID, intakeAtmAmount * intakeReduction);
+            if (intakeLqdAmount > 0) part.RequestResource(intakeLqdID, intakeLqdAmount * intakeReduction);
+        }
+        public override int getPowerPriority()
+        {
+            /*
+             *           \/       \\
+             *     ___  _@@       @@_  ___
+             *    (___)(_)         (_)(___)
+             *    //|| ||           || ||\\
+             *
+             * What do you call two ants who have a baby together?
+             * Pair ants
+             */
+            return (int)powerPriority;
+        }
+    }
+
+
+    [KSPModule("Radiator")]
     class HeatPumpRadiator : FNRadiator
     {
         // Duplicate code from UniversalCrustExtractor.cs

--- a/GameData/WarpPlugin/Localization/Parts/en-us.cfg
+++ b/GameData/WarpPlugin/Localization/Parts/en-us.cfg
@@ -72,6 +72,7 @@
 		#LOC_KSPIE_manuf64 = SM Industries
 		#LOC_KSPIE_manuf65 = Sin Phi Heavy Industry
 		#LOC_KSPIE_manuf66 = C.O.N.V.I.C.T J. Barron Temperature Management Solutions
+        #LOC_KSPIE_manuf67 = Cohen's Unindicted Co-conspirators Tanning Salon
 		#LOC_KSPIE_manuf67 = Zzz
 		
 		// Other
@@ -1105,6 +1106,10 @@
 		#LOC_KSPIE_HeatPumpRadiator_title = Heat Pump Drill
 		#LOC_KSPIE_HeatPumpRadiator_descr = A breakthrough in radiator technology allows WasteHeat to be disposed of underground, perfect for base building regardless of atmosphere status. Per RFC 2119, this heat pump radiator SHOULD be deployed at night, and SHOULD be in the shade during the day. For exceptional performance, deployment MUST be under water. For ultimate performance, increase drill size and get 10m underground. Deployment MUST NOT be done in lava and the heat pump SHOULD NOT be exposed to ionizing radiation. This reverses the polarity of the neutron flow. Polarity reversal of the neutron flow voids the warranty, and is NOT RECOMMENDED.
 		#LOC_KSPIE_HeatPumpRadiator_tags = radiator heat pump convection convect thermal wasteheat radiat control drill
+
+        #LOC_KSPIE_ActiveCoolingSystem_title = Active Cooling System
+        #LOC_KSPIE_ActiveColingSystem_descr = After Individual #1's disasterous 45th attempt that brought world wide ridicule, shame, and pity, Individual #1 retreated to the bunker where he started development of attempt #46. Attempt #46 was a mild success, but it led to new developments in temperature management, and the Active Cooling System (ACS) you're seeing in front of you. The ACS works by force convecting excess waste heat from the inside of the ship, and it can either use atmosphere or liquids to do so. To use in water, place the ACS under water. Warranty void if Individual #1 is exposed to Peach flavored mints.
+        #LOC_KSPIE_ActiveCoolingSystem_tags = radiator heat active convect thermal wasteheat
 
 		// Science
 		

--- a/GameData/WarpPlugin/Parts/Radiators/ActiveCoolingSystem/ActiveCoolingSystem.cfg
+++ b/GameData/WarpPlugin/Parts/Radiators/ActiveCoolingSystem/ActiveCoolingSystem.cfg
@@ -11,9 +11,9 @@ PART
 	cost = 1650
 	category = Thermal
 	subcategory = 0
-	title = Active Cooling System v3// #autoLOC_500724 //#autoLOC_500724 = Engine Pre-cooler
-	manufacturer = test // #autoLOC_501624 //#autoLOC_501624 = C7 Aerospace Division
-	description = test // #autoLOC_500725 //#autoLOC_500725 = Advanced materials allow this cooler to wick away the heat from attached engines. In addition, it features additional intake area optimized for supersonic flight and powerful static suction.
+	title = #LOC_KSPIE_ActiveCoolingSystem_title
+	manufacturer = #LOC_KSPIE_manuf67
+	description = #LOC_KSPIE_ActiveColingSystem_descr
 	attachRules = 1,1,1,1,0
 	mass = 0.15
 	dragModelType = default
@@ -25,10 +25,10 @@ PART
 	minimum_drag = 0.3
 	angularDrag = 1
 	crashTolerance = 10
-	maxTemp = 4000 // 2000 // = 2900
+	maxTemp = 3200 // 2000 // = 2900
 	fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
-	tags = #autoLOC_500726 //#autoLOC_500726 = aero (air aircraft breathe cone fligh fuel inlet intake jet oxygen plane suck supersonic tank
+	tags = #LOC_KSPIE_ActiveCoolingSystem_tags
 	buoyancy = 0.01
 	rescaleFactor = 2
 

--- a/GameData/WarpPlugin/Parts/Radiators/ActiveCoolingSystem/ActiveCoolingSystem.cfg
+++ b/GameData/WarpPlugin/Parts/Radiators/ActiveCoolingSystem/ActiveCoolingSystem.cfg
@@ -1,0 +1,112 @@
+PART
+{
+	name = activeCoolingSystemv3
+	module = Part
+	author = SernisD
+	node_stack_top = 0.0, 0.9375, 0.0, 0.0, 1.0, 0.0
+	node_stack_bottom = 0.0, -0.9375, 0.0, 0.0, -1.0, 0.0
+	node_attach = 0.0, 0.0, 0.625, 0.0, 0.0, -1.0, 1
+	TechRequired = heat
+	entryCost = 6200
+	cost = 1650
+	category = Thermal
+	subcategory = 0
+	title = Active Cooling System v3// #autoLOC_500724 //#autoLOC_500724 = Engine Pre-cooler
+	manufacturer = test // #autoLOC_501624 //#autoLOC_501624 = C7 Aerospace Division
+	description = test // #autoLOC_500725 //#autoLOC_500725 = Advanced materials allow this cooler to wick away the heat from attached engines. In addition, it features additional intake area optimized for supersonic flight and powerful static suction.
+	attachRules = 1,1,1,1,0
+	mass = 0.15
+	dragModelType = default
+	thermalMassModifier = 1.5
+	skinMassPerArea = 2
+	emissiveConstant = 0.95
+	heatConductivity = 0.24
+	maximum_drag = 0.2
+	minimum_drag = 0.3
+	angularDrag = 1
+	crashTolerance = 10
+	maxTemp = 4000 // 2000 // = 2900
+	fuelCrossFeed = True
+	bulkheadProfiles = size1, srf
+	tags = #autoLOC_500726 //#autoLOC_500726 = aero (air aircraft breathe cone fligh fuel inlet intake jet oxygen plane suck supersonic tank
+	buoyancy = 0.01
+	rescaleFactor = 2
+
+    //              .     .  .      +     .      .          .
+    //         .       .      .     #       .           .
+    //            .      .         ###            .      .      .
+    //          .      .   "#:. .:##"##:. .:#"  .      .
+    //              .      . "####"###"####"  .
+    //           .     "#:.    .:#"###"#:.    .:#"  .        .       .
+    //      .             "#########"#########"        .        .
+    //            .    "#:.  "####"###"####"  .:#"   .       .
+    //         .     .  "#######""##"##""#######"                  .
+    //                    ."##"#####"#####"##"           .      .
+    //        .   "#:. ...  .:##"###"###"##:.  ... .:#"     .
+    //          .     "#######"##"#####"##"#######"      .     .
+    //        .    .     "#####""#######""#####"    .      .
+    //                .     "      000      "    .     .
+    //           .         .   .   000     .        .       .
+    //    .. .. ..................O000O........................ ......
+    //
+    // Why don't you ever see elephants hiding in trees?
+    // Because they're so good at it.
+    //
+
+	MODEL
+	{
+		model = Squad/Parts/Structural/mk1Parts/Nacelle2
+	}
+
+	MODULE
+	{
+		name = ActiveRadiator3
+	}
+
+	MODULE
+	{
+		name = AtmosphericIntake
+		area = 0.2
+		intakeTransformName = Intake
+		intakeSpeed = 100
+	}
+
+	MODULE
+	{
+		name = ModuleResourceIntake
+		resourceName = IntakeLqd
+		checkForOxygen = false
+		area = 0.02
+		intakeSpeed = 100
+		underwaterOnly = true
+		intakeTransformName = Intake
+
+	}
+
+	MODULE
+	{
+		name = ModuleAnimateHeat
+		ThermalAnim = Nacelle2Heat
+	}
+	
+	RESOURCE
+	{
+		name = IntakeAtm
+		amount = 0
+		maxAmount = 10
+	}
+
+	RESOURCE
+	{
+		name = IntakeLqd
+		amount = 0
+		maxAmount = 100
+	}
+
+	RESOURCE
+	{
+		name = WasteHeat
+		amount = 0
+		maxAmount = 10000
+	}
+}


### PR DESCRIPTION
A work in progress of an active cooling system. It uses IntakeAtm and/or IntakeLqd to force convect WasteHeat from the vessel.

Levers that can be adjusted (used as an upgrade path, game balancing, etc).
  - Pump Speed (used as a multiplier, currently 100)
  - Intake storage (coolant usable amount)
  - Surface Area (currently 100)

Potential ideas:
  - Have surface area be configurable in the VAB. Affects cost, and part mass by suitable amounts.
  - Upgrades for jets affect pump speed (both how quickly we can do intake, and how fast we can force convect)
  - Upgrades for increasing surface area.

Some screen shots (no artwork, reusing Engine Precooler).

![image](https://user-images.githubusercontent.com/73044166/96388209-1ad7af80-11f3-11eb-93ba-eeff966a7155.png)
![image](https://user-images.githubusercontent.com/73044166/96388220-39d64180-11f3-11eb-9a3e-471412cb1406.png)
![image](https://user-images.githubusercontent.com/73044166/96388227-43f84000-11f3-11eb-8a92-51ced83fc1ba.png)
![image](https://user-images.githubusercontent.com/73044166/96388236-5a9e9700-11f3-11eb-8c0e-6365592cfa8b.png)

And some more. In this case, the radiator area on the reactor is 96.75m2, and on the titanium one it is 90m2.

![image](https://user-images.githubusercontent.com/73044166/96388583-920e4300-11f5-11eb-81fd-2051f537cae2.png)
![image](https://user-images.githubusercontent.com/73044166/96388630-def21980-11f5-11eb-89e0-c359c6678321.png)

(Keeping in mind that the built in radiator and the titanium one have a 10k% buf, and upto another bonus when in/near water).

There will need to be some game balancing done to make all the radiators work as expected.