### PR TITLE
Further display improvements

### DIFF
--- a/FNPlugin/Beamedpower/BeamedPowerReceiver.cs
+++ b/FNPlugin/Beamedpower/BeamedPowerReceiver.cs
@@ -2118,7 +2118,6 @@ namespace FNPlugin
 
             var alternatorPower = alternatorRatio * powerInputMegajoules * 0.001;
 
-            var alternatorSupplyRatio = alternatorPower / total_thermal_power_provided;
             var alternatorWasteheat = Math.Min(alternatorPower * AverageEfficiencyFraction, GetCurrentUnfilledResourceDemand(ResourceManager.FNRESOURCE_MEGAJOULES) * AverageEfficiencyFraction);
 
             supplyFNResourcePerSecond(alternatorPower, ResourceManager.FNRESOURCE_MEGAJOULES);
@@ -2129,8 +2128,8 @@ namespace FNPlugin
 
             if (outputModuleResource != null)
             {
-                outputModuleResource.rate = alternatorPower * 1000;
-                mockInputResource.rate = alternatorPower * -1000;
+                outputModuleResource.rate = alternatorPower * GameConstants.ecPerMJ;
+                mockInputResource.rate = alternatorPower * -GameConstants.ecPerMJ;
             }
         }
 

--- a/FNPlugin/Beamedpower/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/Beamedpower/MicrowavePowerTransmitter.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Extensions;
+﻿using FNPlugin.Constants;
+using FNPlugin.Extensions;
 using FNPlugin.Microwave;
 using KSP.Localization;
 using System;
@@ -581,13 +582,12 @@ namespace FNPlugin.Beamedpower
                     requestedPower = Math.Min(Math.Min(power_capacity, availablePower) * powerTransmissionRatio, effectiveResourceThrotling * availablePower);
                 }
 
-                var receivedPower = CheatOptions.InfiniteElectricity
-                    ? requestedPower
-                    : consumeFNResourcePerSecond(requestedPower, ResourceManager.FNRESOURCE_MEGAJOULES);
+                double receivedPower = CheatOptions.InfiniteElectricity ? requestedPower :
+                    consumeFNResourcePerSecond(requestedPower, ResourceManager.FNRESOURCE_MEGAJOULES);
 
-                nuclear_power += 1000 * transmissionEfficiencyRatio * receivedPower;
+                nuclear_power += GameConstants.ecPerMJ * transmissionEfficiencyRatio * receivedPower;
 
-                solar_power += 1000 * transmissionEfficiencyRatio * solarCells.Sum(m => m.SolarPower);
+                solar_power += GameConstants.ecPerMJ * transmissionEfficiencyRatio * solarCells.Sum(m => m.SolarPower);
 
                 // generate wasteheat for converting electric power to beamed power
                 if (!CheatOptions.IgnoreMaxTemperature)

--- a/FNPlugin/Beamedpower/MicrowavePowerTransmitter.cs
+++ b/FNPlugin/Beamedpower/MicrowavePowerTransmitter.cs
@@ -533,8 +533,7 @@ namespace FNPlugin.Beamedpower
             atmosphericAbsorptionPercentage = activeBeamGenerator.atmosphericAbsorptionPercentage;
             waterAbsorptionPercentage = activeBeamGenerator.waterAbsorptionPercentage * moistureModifier;
 
-            double inputPower = nuclear_power + solar_power;
-            beamedpower = PluginHelper.getFormattedPowerString(inputPower);
+            beamedpower = PluginHelper.getFormattedPowerString((nuclear_power + solar_power) / GameConstants.ecPerMJ);
             solarCells = vessel.FindPartModulesImplementing<ISolarPower>();
         }
 

--- a/FNPlugin/Collectors/AntimatterCollector.cs
+++ b/FNPlugin/Collectors/AntimatterCollector.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Linq;
+﻿using FNPlugin.Constants;
 using FNPlugin.Extensions;
 using FNPlugin.Resources;
+using System;
+using System.Linq;
 
-namespace FNPlugin 
+namespace FNPlugin
 {
     class AntimatterCollector : ResourceSuppliableModule    
     {
@@ -76,15 +77,9 @@ namespace FNPlugin
                 return;
             }
 
-            var fixedPowerReqKW = powerReqKW * TimeWarp.fixedDeltaTime;
-            // first attemp to get power more megajoule network
-            var fixedRecievedChargeKW = CheatOptions.InfiniteElectricity
-                ? fixedPowerReqKW
-                : consumeFNResource(fixedPowerReqKW * 0.001, ResourceManager.FNRESOURCE_MEGAJOULES, TimeWarp.fixedDeltaTime) * 1000;
-            // alternativly attempt to use electric charge
-            if (fixedRecievedChargeKW <= fixedPowerReqKW)
-                fixedRecievedChargeKW += part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, fixedPowerReqKW - fixedRecievedChargeKW);
-            var powerRatio = fixedPowerReqKW > 0 ? fixedRecievedChargeKW / fixedPowerReqKW : 0;
+            double fixedPowerReqKW = powerReqKW * TimeWarp.fixedDeltaTime;
+            double fixedReceivedChargeKW = consumeMegajoules(fixedPowerReqKW / GameConstants.ecPerMJ, true, false, true) * GameConstants.ecPerMJ;
+            double powerRatio = fixedPowerReqKW > 0.0 ? fixedReceivedChargeKW / fixedPowerReqKW : 0.0;
             
             _effectiveFlux = powerRatio * flux;
             part.RequestResource(_antimatterDef.id, -_effectiveFlux * TimeWarp.fixedDeltaTime - _offlineResource, ResourceFlowMode.STACK_PRIORITY_SEARCH);

--- a/FNPlugin/Collectors/RegolithCollector.cs
+++ b/FNPlugin/Collectors/RegolithCollector.cs
@@ -1,5 +1,6 @@
 ﻿using FNPlugin.Constants;
 using FNPlugin.Extensions;
+using FNPlugin.Powermanagement;
 using FNPlugin.Resources;
 using KSP.Localization;
 using System;
@@ -336,24 +337,15 @@ namespace FNPlugin.Collectors
 
             if (dConcentrationRegolith > 0 && (dRegolithSpareCapacity > 0))
             {
-                // calculate available power
-                double dPowerReceivedMW = Math.Max(consumeFNResource(dPowerRequirementsMW * TimeWarp.fixedDeltaTime, ResourceManager.FNRESOURCE_MEGAJOULES, TimeWarp.fixedDeltaTime), 0);
-                double dNormalisedRevievedPowerMW = dPowerReceivedMW / TimeWarp.fixedDeltaTime;
+                // Determine available power, using EC if below 2 MW required
+                double powerreceivedMW = consumeMegajoules(dPowerRequirementsMW * TimeWarp.fixedDeltaTime,
+                    true, false, dPowerRequirementsMW < 2.0) / TimeWarp.fixedDeltaTime;
 
-                // if power requirement sufficiently low, retrieve power from KW source
-                if (dPowerRequirementsMW < 2 && dNormalisedRevievedPowerMW <= dPowerRequirementsMW)
-                {
-                    double dRequiredKW = (dPowerRequirementsMW - dNormalisedRevievedPowerMW) * 1000;
-                    double dReceivedKW = part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, dRequiredKW * TimeWarp.fixedDeltaTime);
-                    dPowerReceivedMW += (dReceivedKW / 1000);
-                }
-
-                dLastPowerPercentage = offlineCollecting ? dLastPowerPercentage : (float)(dPowerReceivedMW / dPowerRequirementsMW / TimeWarp.fixedDeltaTime);
+                dLastPowerPercentage = offlineCollecting ? dLastPowerPercentage : powerreceivedMW / dPowerRequirementsMW;
 
                 // show in GUI
                 strCollectingStatus = Localizer.Format("#LOC_KSPIE_RegolithCollector_Collectingregolith");//"Collecting regolith"
             }
-
             else
             {
                 dLastPowerPercentage = 0;

--- a/FNPlugin/Collectors/SolarWindCollector.cs
+++ b/FNPlugin/Collectors/SolarWindCollector.cs
@@ -703,14 +703,6 @@ namespace FNPlugin.Collectors
                 // calculate available power
                 var receivedPowerMw = consumeFNResourcePerSecond(dPowerRequirementsMw * heliumRatio, ResourceManager.FNRESOURCE_MEGAJOULES);
 
-                // if power requirement sufficiently low, retreive power from KW source
-                //if (dPowerRequirementsMw < 2 && revievedPowerMw <= dPowerRequirementsMw)
-                //{
-                //    var requiredKw = (dPowerRequirementsMw - revievedPowerMw) * 1000;
-                //    var receivedKw = part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, heliumRatio * requiredKw * TimeWarp.fixedDeltaTime) / TimeWarp.fixedDeltaTime;
-                //    revievedPowerMw += (receivedKw * 0.001);
-                //}
-
                 dLastPowerRatio = offlineCollecting ? dLastPowerRatio : (dPowerRequirementsMw > 0 ? receivedPowerMw / dPowerRequirementsMw : 0);
 
                 supplyManagedFNResourcePerSecond(dWasteheatProductionMw * dLastPowerRatio, ResourceManager.FNRESOURCE_WASTEHEAT);

--- a/FNPlugin/Collectors/UniversalCrustExtractor.cs
+++ b/FNPlugin/Collectors/UniversalCrustExtractor.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Resources;
+﻿using FNPlugin.Powermanagement;
+using FNPlugin.Resources;
 using KSP.Localization;
 using System;
 using System.Collections.Generic;
@@ -476,17 +477,9 @@ namespace FNPlugin.Collectors
                 return 100;
 
             double dPowerRequirementsMW = PluginHelper.PowerConsumptionMultiplier * mwRequirements;
-
-            // calculate the provided power and consume it
-            double dNormalisedRecievedPowerMW = consumeFNResourcePerSecond(dPowerRequirementsMW, ResourceManager.FNRESOURCE_MEGAJOULES);
-
-            // when the requirements are low enough, we can get the power needed from stock energy charge
-            if (dPowerRequirementsMW < 5 && dNormalisedRecievedPowerMW <= dPowerRequirementsMW)
-            {
-                double dRequiredKW = (dPowerRequirementsMW - dNormalisedRecievedPowerMW) * 1000;
-                double dReceivedKW = part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, dRequiredKW * deltaTime) / deltaTime;
-                dNormalisedRecievedPowerMW += dReceivedKW / 1000;
-            }
+            // Determine available power, using EC if below 5 MW required
+            double dNormalisedRecievedPowerMW = consumeMegajoules(dPowerRequirementsMW * TimeWarp.fixedDeltaTime,
+                true, false, dPowerRequirementsMW < 5.0) / TimeWarp.fixedDeltaTime;
 
             // Workaround for some weird glitches where dNormalisedRecievedPowerMW gets slightly smaller than it should be during timewarping
             return dNormalisedRecievedPowerMW / dPowerRequirementsMW;

--- a/FNPlugin/Powermanagement/FNBatteryGenerator.cs
+++ b/FNPlugin/Powermanagement/FNBatteryGenerator.cs
@@ -1,3 +1,4 @@
+using FNPlugin.Constants;
 using FNPlugin.Extensions;
 using System;
 using System.Collections.Generic;
@@ -153,7 +154,7 @@ namespace FNPlugin.Powermanagement
                         if (currentFuelRatio < fuelRatio)
                             fuelRatio = currentFuelRatio;
 
-                        var currentBatterySupplyRemaining = currentFuelRatio / fixedDeltaTime / 1000;
+                        var currentBatterySupplyRemaining = currentFuelRatio / fixedDeltaTime / GameConstants.ecPerMJ;
                         if (currentBatterySupplyRemaining < batterySupplyRemaining)
                             batterySupplyRemaining = currentBatterySupplyRemaining;
 

--- a/FNPlugin/Powermanagement/FNFissionGeneratorAdapter.cs
+++ b/FNPlugin/Powermanagement/FNFissionGeneratorAdapter.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Power;
+﻿using FNPlugin.Constants;
+using FNPlugin.Power;
 using FNPlugin.Wasteheat;
 using System;
 using UnityEngine;
@@ -121,13 +122,13 @@ namespace FNPlugin
                 float generatorMax = _field_max.GetValue<float>(moduleGenerator);
                 float generatorEfficiency = _field_efficiency.GetValue<float>(moduleGenerator);
 
-                efficiency = (generatorEfficiency * 100).ToString("F2") + " %";
+                efficiency = generatorEfficiency.ToString("P2");
 
                 //extract power otherwise we end up with double power
                 part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, generatorRate * fixedDeltaTime);
 
-                var megajoulesRate = generatorRate / 1000;
-                var maxMegajoulesRate = generatorMax / 1000;
+                var megajoulesRate = generatorRate / GameConstants.ecPerMJ;
+                var maxMegajoulesRate = generatorMax / GameConstants.ecPerMJ;
 
                 _resourceBuffers.UpdateVariable(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, generatorRate);
                 _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_MEGAJOULES, megajoulesRate);

--- a/FNPlugin/Powermanagement/FNGenerator.cs
+++ b/FNPlugin/Powermanagement/FNGenerator.cs
@@ -1,3 +1,4 @@
+using FNPlugin.Constants;
 using FNPlugin.Extensions;
 using FNPlugin.Power;
 using FNPlugin.Reactors;
@@ -7,7 +8,6 @@ using KSP.Localization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using TweakScale;
 using UnityEngine;
 
@@ -635,7 +635,7 @@ namespace FNPlugin
                         outputModuleResource.rate = maximumGeneratorPowerEC;
 
                     maximumGeneratorPowerEC = outputModuleResource.rate;
-                    maximumGeneratorPowerMJ = maximumGeneratorPowerEC / 1000;
+                    maximumGeneratorPowerMJ = maximumGeneratorPowerEC / GameConstants.ecPerMJ;
 
                     mockInputResource = new ModuleResource();
                     mockInputResource.name = outputModuleResource.name;
@@ -803,7 +803,7 @@ namespace FNPlugin
             else
                 maximumGeneratorPowerMJ = maximumPower * maxEfficiency * 0.6;
 
-            outputModuleResource.rate = maximumGeneratorPowerMJ * 1000;
+            outputModuleResource.rate = maximumGeneratorPowerMJ * GameConstants.ecPerMJ;
         }
 
         private PowerSourceSearchResult FindThermalPowerSource()
@@ -1225,7 +1225,7 @@ namespace FNPlugin
                 if (outputModuleResource != null)
                 {
                     currentPowerForGeneratorMJ = Math.Min(maximumGeneratorPowerMJ, electricdtps);
-                    outputModuleResource.rate = currentPowerForGeneratorMJ * 1000;
+                    outputModuleResource.rate = currentPowerForGeneratorMJ * GameConstants.ecPerMJ;
                     mockInputResource.rate = outputModuleResource.rate;
                 }
 

--- a/FNPlugin/Powermanagement/FNGeneratorAdapter.cs
+++ b/FNPlugin/Powermanagement/FNGeneratorAdapter.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Power;
+﻿using FNPlugin.Constants;
+using FNPlugin.Power;
 using System;
 using UnityEngine;
 
@@ -99,46 +100,30 @@ namespace FNPlugin
             }
             catch (Exception e)
             {
-                Debug.LogError("[KSPI]: Exception in FNGeneratorAdapter.OnStart " + e.Message);
+                Debug.LogError("[KSPI]: Exception in FNGeneratorAdapter.OnStart " + e.ToString());
                 throw;
             }
         }
 
         public override void OnFixedUpdate()
         {
-            try
-            {
-                if (!HighLogic.LoadedSceneIsFlight) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
 
-                if (_moduleGenerator == null) return;
+            if (_moduleGenerator == null) return;
 
-                active = true;
-                base.OnFixedUpdate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNGeneratorAdapter.OnFixedUpdate " + e.Message);
-                throw;
-            }
+            active = true;
+            base.OnFixedUpdate();
         }
 
 
         public void FixedUpdate()
         {
-            try
-            {
-                if (!HighLogic.LoadedSceneIsFlight) return;
+            if (!HighLogic.LoadedSceneIsFlight) return;
 
-                if (_moduleGenerator == null) return;
+            if (_moduleGenerator == null) return;
 
-                if (!active)
-                    base.OnFixedUpdate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNGeneratorAdapter.OnFixedUpdate " + e.Message);
-                throw;
-            }
+            if (!active)
+                base.OnFixedUpdate();
         }
 
         public override string getResourceManagerDisplayName()
@@ -154,27 +139,21 @@ namespace FNPlugin
 
         public override void OnFixedUpdateResourceSuppliable(double fixedDeltaTime)
         {
-            try
-            {
-                if (_moduleGenerator == null) return;
+            if (_moduleGenerator == null) return;
 
-                if (_outputType == ResourceType.other) return;
+            if (_outputType == ResourceType.other) return;
 
-                var generatorRate = _moduleOutputResource.rate;
-                _mockInputResource.rate = generatorRate;
+            var generatorRate = _moduleOutputResource.rate;
+            _mockInputResource.rate = generatorRate;
 
-                double generatorSupply = _outputType == ResourceType.megajoule ? generatorRate : generatorRate / 1000;
+            double generatorSupply = _outputType == ResourceType.megajoule ? generatorRate :
+                generatorRate / GameConstants.ecPerMJ;
 
-                if (maintainsBuffer)
-                    _resourceBuffers.UpdateBuffers();
+            if (maintainsBuffer)
+                _resourceBuffers.UpdateBuffers();
 
-                megaJouleGeneratorPowerSupply = supplyFNResourcePerSecondWithMax(generatorSupply, generatorSupply, ResourceManager.FNRESOURCE_MEGAJOULES);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError("[KSPI]: Exception in FNGeneratorAdapter.OnFixedUpdateResourceSuppliable " + e.Message);
-                throw;
-            }
+            megaJouleGeneratorPowerSupply = supplyFNResourcePerSecondWithMax(generatorSupply,
+                generatorSupply, ResourceManager.FNRESOURCE_MEGAJOULES);
         }
     }
 }

--- a/FNPlugin/Powermanagement/MegajoulesResourceManager.cs
+++ b/FNPlugin/Powermanagement/MegajoulesResourceManager.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Extensions;
+﻿using FNPlugin.Constants;
+using FNPlugin.Extensions;
 using KSP.Localization;
 using System;
 using UnityEngine;
@@ -7,7 +8,6 @@ namespace FNPlugin.Powermanagement
 {
     internal class MegajoulesResourceManager : ResourceManager
     {
-        private const double EC_PER_MJ = 1000.0;
         private readonly PartResourceDefinition electricResourceDefinition;
 
         private double lastECNeeded;
@@ -66,12 +66,12 @@ namespace FNPlugin.Powermanagement
 
         private void SupplyEC(double timeWarpDT, double ecToSupply)
         {
-            ecToSupply = Math.Min(ecToSupply, current.Supply * EC_PER_MJ * timeWarpDT);
-            double powerConverted = part.RequestResource(electricResourceDefinition.id, -ecToSupply) / -EC_PER_MJ / timeWarpDT;
+            ecToSupply = Math.Min(ecToSupply, current.Supply * GameConstants.ecPerMJ * timeWarpDT);
+            double powerConverted = part.RequestResource(electricResourceDefinition.id, -ecToSupply) / -GameConstants.ecPerMJ / timeWarpDT;
             current.Supply -= powerConverted;
             current.StableSupply -= powerConverted;
             current.TotalSupplied += powerConverted;
-            current.Demand += ecToSupply / EC_PER_MJ / timeWarpDT;
+            current.Demand += ecToSupply / GameConstants.ecPerMJ / timeWarpDT;
             mjConverted += powerConverted;
         }
 
@@ -94,7 +94,7 @@ namespace FNPlugin.Powermanagement
                 else
                 {
                     // Add a demand for the difference in EC only
-                    double demand = (ecNeeded - lastECNeeded) / EC_PER_MJ / timeWarpDT;
+                    double demand = (ecNeeded - lastECNeeded) / GameConstants.ecPerMJ / timeWarpDT;
                     current.Demand += demand;
                     mjConverted += demand;
                 }

--- a/FNPlugin/Refinery/InterstellarRefinery.cs
+++ b/FNPlugin/Refinery/InterstellarRefinery.cs
@@ -1,4 +1,5 @@
-﻿using FNPlugin.Refinery.Activity;
+﻿using FNPlugin.Constants;
+using FNPlugin.Refinery.Activity;
 using KSP.Localization;
 using System;
 using System.Collections.Generic;
@@ -213,32 +214,29 @@ namespace FNPlugin.Refinery
 
         public void Update()
         {
-            try
+            if (HighLogic.LoadedSceneIsEditor)
+                return;
+
+            if (_current_activity == null)
             {
-                if (HighLogic.LoadedSceneIsEditor)
-                    return;
-
-                if (_current_activity == null)
-                {
-                    powerSupply.DisplayName = part.partInfo.title;
-                    return;
-                }
-
-                powerSupply.DisplayName = part.partInfo.title + " (" + _current_activity.ActivityName + ")";
+                powerSupply.DisplayName = part.partInfo.title;
             }
-            catch (Exception e)
+            else
             {
-                Debug.LogError("[KSPI]: InterstellarRefineryController Exception " + e.Message);
+                powerSupply.DisplayName = part.partInfo.title + " (" + _current_activity.ActivityName + ")";
             }
         }
 
         public override void OnUpdate()
         {
-            status_str = Localizer.Format("#LOC_KSPIE_Refinery_Offline");//"Offline"
-
-            if (_current_activity == null) return;
-
-            status_str = _current_activity.Status;
+            if (_current_activity == null)
+            {
+                status_str = Localizer.Format("#LOC_KSPIE_Refinery_Offline");//"Offline"
+            }
+            else
+            {
+                status_str = _current_activity.Status;
+            }
         }
 
         public void FixedUpdate()
@@ -259,14 +257,14 @@ namespace FNPlugin.Refinery
                 ? powerRequest
                 : powerSupply.ConsumeMegajoulesPerSecond(powerRequest);
 
-
             var shortage = Math.Max(currentPowerReq - consumedPowerMW, 0);
 
             var fixedDeltaTime = (double)(decimal)TimeWarp.fixedDeltaTime;
 
-            var receivedElectricCharge = part.RequestResource("ElectricCharge", shortage * 1000 * fixedDeltaTime) / fixedDeltaTime;
+            var receivedElectricCharge = part.RequestResource("ElectricCharge", shortage *
+                GameConstants.ecPerMJ * fixedDeltaTime) / fixedDeltaTime;
 
-            consumedPowerMW += receivedElectricCharge / 1000;
+            consumedPowerMW += receivedElectricCharge / GameConstants.ecPerMJ;
 
             var power_ratio = currentPowerReq > 0 ? consumedPowerMW / currentPowerReq : 0;
 

--- a/FNPlugin/Storage/AntimatterStorageTank.cs
+++ b/FNPlugin/Storage/AntimatterStorageTank.cs
@@ -20,10 +20,10 @@ namespace FNPlugin
         public double chargeStatus = 1000;
         [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiActiveEditor = true, guiUnits = "K", guiName = "#LOC_KSPIE_AntimatterStorageTank_MaxTemperature"), UI_FloatRange(stepIncrement = 10f, maxValue = 1000f, minValue = 40f)]//Maximum Temperature
         public float maxTemperature = 340;
-        [KSPField(groupName = GROUP, isPersistant = true, guiActiveEditor = true, guiUnits = "g", guiName = "#LOC_KSPIE_AntimatterStorageTank_MaxAcceleration"), UI_FloatRange(stepIncrement = 0.05f, maxValue = 10f, minValue = 0.05f)]//Maximum Acceleration
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiActiveEditor = true, guiUnits = "g", guiName = "#LOC_KSPIE_AntimatterStorageTank_MaxAcceleration"), UI_FloatRange(stepIncrement = 0.05f, maxValue = 10f, minValue = 0.05f)]//Maximum Acceleration
         public float maxGeeforce = 1;
 
-        [KSPField(groupName = GROUP, guiName = "#LOC_KSPIE_AntimatterStorageTank_ModuleCost")]//Module Cost
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiName = "#LOC_KSPIE_AntimatterStorageTank_ModuleCost")]//Module Cost
         public double moduleCost;
         [KSPField]
         public double resourceCost;
@@ -32,9 +32,9 @@ namespace FNPlugin
         [KSPField]
         public double targetCost;
 
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_StoredMass")]//Stored Mass
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_StoredMass")]//Stored Mass
         public double storedMassMultiplier = 1;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_StoredTargetMass")]//Stored Target Mass
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_StoredTargetMass")]//Stored Target Mass
         public double storedTargetMassMultiplier = 1;
 
         [KSPField(isPersistant = true)]
@@ -43,19 +43,19 @@ namespace FNPlugin
         public double storedInitialCostMultiplier = 1;
         [KSPField(isPersistant = true)]
         public double storedTargetCostMultiplier = 1;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_ScalingFactor")]//Scaling Factor
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_ScalingFactor")]//Scaling Factor
         public double storedScalingfactor = 1;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_AntomatterDensity")]//Antomatter Density
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_AntomatterDensity")]//Antomatter Density
         public double antimatterDensity;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_InitialMass", guiUnits = " t", guiFormat = "F3")]//Initial Mass
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_InitialMass", guiUnits = " t", guiFormat = "F3")]//Initial Mass
         public double initialMass;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_TargetMass", guiUnits = " t", guiFormat = "F3")]//Target Mass
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_TargetMass", guiUnits = " t", guiFormat = "F3")]//Target Mass
         public double targetMass;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_DeltaMass", guiUnits = " t", guiFormat = "F3")]//Delta Mass
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_DeltaMass", guiUnits = " t", guiFormat = "F3")]//Delta Mass
         public float moduleMassDelta;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_AttachedTanksCount")]//Attached Tanks Count
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_AttachedTanksCount")]//Attached Tanks Count
         public double attachedAntimatterTanksCount;
-        [KSPField(groupName = GROUP, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_ResourceRatio", guiFormat = "F3")]//Resource Ratio
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_ResourceRatio", guiFormat = "F3")]//Resource Ratio
         public double resourceRatio;
         [KSPField(isPersistant = true)]
         public double emptyCost;
@@ -120,19 +120,19 @@ namespace FNPlugin
         public double massGeeforceDivider = 40;
         [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiName = "#LOC_KSPIE_AntimatterStorageTank_RequiredPower")]//Required Power
         public double effectivePowerNeeded;
-        [KSPField(groupName = GROUP, guiName = "#LOC_KSPIE_AntimatterStorageTank_Exploding")]//Exploding
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiName = "#LOC_KSPIE_AntimatterStorageTank_Exploding")]//Exploding
         public bool exploding = false;
-        [KSPField(groupName = GROUP, guiName = "#LOC_KSPIE_AntimatterStorageTank_Charge")]//Charge
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiName = "#LOC_KSPIE_AntimatterStorageTank_Charge")]//Charge
         public string chargeStatusStr;
-        [KSPField(groupName = GROUP, guiName = "#LOC_KSPIE_AntimatterStorageTank_Status")]//Status
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiName = "#LOC_KSPIE_AntimatterStorageTank_Status")]//Status
         public string statusStr;
         [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActiveEditor = true, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_Current")]//Current
         public string capacityStr;
-        [KSPField(groupName = GROUP, guiActiveEditor = true, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_Maximum")]//Maximum
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActiveEditor = true, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_Maximum")]//Maximum
         public string maxAmountStr;
-        [KSPField(groupName = GROUP, guiActiveEditor = false, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_Cur_MaxTemp", guiFormat = "F0")]//Cur/Max Temp
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActiveEditor = false, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_Cur_MaxTemp", guiFormat = "F0")]//Cur/Max Temp
         public string TemperatureStr;
-        [KSPField(groupName = GROUP, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_CurMaxGeeforce")]//Cur/Max Geeforce
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActive = true, guiName = "#LOC_KSPIE_AntimatterStorageTank_CurMaxGeeforce")]//Cur/Max Geeforce
         public string GeeforceStr;
         [KSPField]
         public bool canExplodeFromHeat = false;
@@ -683,40 +683,10 @@ namespace FNPlugin
 
             if (effectivePowerNeeded > 0)
             {
-                var powerMultiplier = chargeStatus >= maxCharge ? 0.5 : 1;
-                var powerRequest = powerMultiplier * 2 * effectivePowerNeeded * TimeWarp.fixedDeltaTime;
-
-                // first try to Access Power megajoules
-                var chargeToAdd = CheatOptions.InfiniteElectricity
-                    ? powerRequest
-                    : consumeFNResource(powerRequest / 1000, ResourceManager.FNRESOURCE_MEGAJOULES) * 1000 / effectivePowerNeeded;
-
+                double powerMultiplier = chargeStatus >= maxCharge ? 0.5 : 1;
+                double powerRequest = powerMultiplier * 2.0 * effectivePowerNeeded * TimeWarp.fixedDeltaTime;
+                double chargeToAdd = consumeMegajoules(powerRequest / GameConstants.ecPerMJ, true, true, true) * GameConstants.ecPerMJ;
                 chargeStatus += chargeToAdd;
-
-                // alternatively just look for any reserves of stored megajoules
-                if (chargeToAdd == 0 && effectivePowerNeeded > 0)
-                {
-                    var moreChargeToAdd = part.RequestResource(ResourceManager.FNRESOURCE_MEGAJOULES, powerRequest / 1000) * 1000 / effectivePowerNeeded;
-
-                    chargeToAdd += moreChargeToAdd;
-                    chargeStatus += moreChargeToAdd;
-                }
-
-                // alternatively attempt to find any KilowattHour energy
-                if (chargeToAdd < TimeWarp.fixedDeltaTime && effectivePowerNeeded > 0)
-                {
-                    var moreChargeToAdd = part.RequestResource("KilowattHour", powerRequest / 3600) * 3600 / effectivePowerNeeded;
-                    chargeToAdd += moreChargeToAdd;
-                    chargeStatus += moreChargeToAdd;
-                }
-
-                // if still not found any power attempt to find any electric charge to survive
-                if (chargeToAdd < TimeWarp.fixedDeltaTime && effectivePowerNeeded > 0)
-                {
-                    var moreChargeToAdd = part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, powerRequest) / effectivePowerNeeded;
-                    chargeToAdd += moreChargeToAdd;
-                    chargeStatus += moreChargeToAdd;
-                }
 
                 if (chargeToAdd >= TimeWarp.fixedDeltaTime)
                     _charging = true;
@@ -850,7 +820,7 @@ namespace FNPlugin
             if (canExplodeFromGeeForce)
                 info.AppendLine(Localizer.Format("#LOC_KSPIE_AntimatterStorageTank_Getinfo2"));//"Maximum Geeforce: 10 G"
             if (canExplodeFromHeat)
-                info.AppendLine(Localizer.Format("#LOC_KSPIE_AntimatterStorageTank_Getinfo3"));//"Maximum Geeforce: 1000 K"
+                info.AppendLine(Localizer.Format("#LOC_KSPIE_AntimatterStorageTank_Getinfo3"));//"Maximum Temperature: 1000 K"
 
             return info.ToString();
         }

--- a/FNPlugin/Storage/FNModuleCryostat.cs
+++ b/FNPlugin/Storage/FNModuleCryostat.cs
@@ -1,8 +1,9 @@
-﻿using FNPlugin.Power;
+﻿using FNPlugin.Constants;
+using FNPlugin.Extensions;
+using FNPlugin.Power;
+using KSP.Localization;
 using System;
 using UnityEngine;
-using KSP.Localization;
-using FNPlugin.Extensions;
 
 namespace FNPlugin
 {
@@ -12,10 +13,13 @@ namespace FNPlugin
     [KSPModule("Cryostat")]
     class FNModuleCryostat : ResourceSuppliableModule
     {
+        public const string GROUP = "FNModuleCryostat";
+        public const string GROUP_TITLE = "Interstellar Cryostat";
+
         // Persistant
-        [KSPField(isPersistant = true, guiActive = true, guiName = "#LOC_IFS_Cryostat_Cooling"), UI_Toggle(disabledText = "#LOC_IFS_Cryostat_On", enabledText = "#LOC_IFS_Cryostat_Off")]//Cooling--On--Off
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiActive = true, guiName = "#LOC_IFS_Cryostat_Cooling"), UI_Toggle(disabledText = "#LOC_IFS_Cryostat_On", enabledText = "#LOC_IFS_Cryostat_Off")]//Cooling--On--Off
         public bool isDisabled = false;
-        [KSPField(isPersistant = true, guiActive = true, guiName = "#LOC_KSPIE_Cryostat_PowerBuffer"), UI_Toggle(disabledText = "#LOC_IFS_Cryostat_Off", enabledText = "#LOC_IFS_Cryostat_On")]//Cooling--On--Off
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = true, guiActive = true, guiName = "#LOC_KSPIE_Cryostat_PowerBuffer"), UI_Toggle(disabledText = "#LOC_IFS_Cryostat_Off", enabledText = "#LOC_IFS_Cryostat_On")]//Cooling--On--Off
         public bool maintainElectricChargeBuffer = true;
 
         [KSPField(isPersistant = true)]
@@ -56,13 +60,13 @@ namespace FNPlugin
         public int initializationCountdown = 10;
 
         //GUI
-        [KSPField(isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Power")]//Power
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Power")]//Power
         public string powerStatusStr = string.Empty;
-        [KSPField(isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Boiloff")]//Boiloff
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Boiloff")]//Boiloff
         public string boiloffStr;
-        [KSPField(isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Temperature", guiFormat = "F3", guiUnits = " K")]//Temperature
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Temperature", guiFormat = "F2", guiUnits = " K")]//Temperature
         public double externalTemperature;
-        [KSPField(isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Internalboiloff")]//internal boiloff
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, isPersistant = false, guiActive = false, guiName = "#LOC_KSPIE_ModuleCryostat_Internalboiloff")]//internal boiloff
         public double boiloff;
 
         private BaseField isDisabledField;
@@ -89,11 +93,11 @@ namespace FNPlugin
             part.temperature = storedTemp;
             requiresPower = powerReqKW > 0;
 
-            isDisabledField = Fields["isDisabled"];
-            boiloffStrField = Fields["boiloffStr"];
-            powerStatusStrField = Fields["powerStatusStr"];
-            externalTemperatureField = Fields["externalTemperature"];
-            maintainElectricChargeBufferField = Fields["maintainElectricChargeBuffer"];
+            isDisabledField = Fields[nameof(isDisabled)];
+            boiloffStrField = Fields[nameof(boiloffStr)];
+            powerStatusStrField = Fields[nameof(powerStatusStr)];
+            externalTemperatureField = Fields[nameof(externalTemperature)];
+            maintainElectricChargeBufferField = Fields[nameof(maintainElectricChargeBuffer)];
 
             if (state == StartState.Editor)
             {
@@ -117,7 +121,7 @@ namespace FNPlugin
             // if electricCharge buffer is missing, add it.
             if (!part.Resources.Contains(InterstellarResourcesConfiguration.Instance.ElectricCharge))
             {
-                ConfigNode node = new ConfigNode("RESOURCE");
+                var node = new ConfigNode("RESOURCE");
                 node.AddValue("name", InterstellarResourcesConfiguration.Instance.ElectricCharge);
                 node.AddValue("maxAmount", requiresPower ? powerReqKW / 50 : 1);
                 node.AddValue("amount", requiresPower ? powerReqKW / 50 : 1);
@@ -173,7 +177,7 @@ namespace FNPlugin
                     return;
                 }
 
-                var atmosphereModifier = convectionMod == -1 ? 0 : convectionMod + part.atmDensity / (convectionMod + 1);
+                double atmosphereModifier = convectionMod == -1 ? 0 : convectionMod + part.atmDensity / (convectionMod + 1);
 
                 externalTemperature = part.temperature;
                 if (Double.IsNaN(externalTemperature) || Double.IsInfinity(externalTemperature))
@@ -182,7 +186,7 @@ namespace FNPlugin
                     externalTemperature = part.skinTemperature;
                 }
 
-                var temperatureModifier = Math.Max(0, externalTemperature - boilOffTemp) / 300; //273.15;
+                var temperatureModifier = Math.Max(0, externalTemperature - boilOffTemp) / 300;
 
                 environmentFactor = atmosphereModifier * temperatureModifier;
 
@@ -216,7 +220,8 @@ namespace FNPlugin
 
         private void UpdatePowerStatusString()
         {
-            powerStatusStr = PluginHelper.getFormattedPowerString(recievedPowerKW) + " / " + PluginHelper.getFormattedPowerString(currentPowerReq);
+            powerStatusStr = PluginHelper.getFormattedPowerString(recievedPowerKW / GameConstants.ecPerMJ) +
+                " / " + PluginHelper.getFormattedPowerString(currentPowerReq / GameConstants.ecPerMJ);
         }
 
         // FixedUpdate is also called while not staged
@@ -229,36 +234,25 @@ namespace FNPlugin
                 return;
             }
 
-            var fixedDeltaTime = (double)(decimal)Math.Round(TimeWarp.fixedDeltaTime, 7);
+            double fixedDeltaTime = TimeWarp.fixedDeltaTime;
 
-            if (!isDisabled &&  currentPowerReq > 0)
+            if (!isDisabled && currentPowerReq > 0.0)
             {
                 UpdateElectricChargeBuffer(Math.Max(currentPowerReq, 0.1 * powerReqKW));
 
-                var fixedPowerReqKW = currentPowerReq * fixedDeltaTime;
-
-                var fixedRecievedChargeKW = CheatOptions.InfiniteElectricity 
-                    ? fixedPowerReqKW
-                    : consumeFNResource(fixedPowerReqKW / 1000, ResourceManager.FNRESOURCE_MEGAJOULES) * 1000;
-
-                if (fixedRecievedChargeKW <= fixedPowerReqKW)
-                    fixedRecievedChargeKW += part.RequestResource(ResourceManager.FNRESOURCE_MEGAJOULES, (fixedPowerReqKW - fixedRecievedChargeKW) / 1000) * 1000;
-
-                if (currentPowerReq < 1000 && fixedRecievedChargeKW <= fixedPowerReqKW)
-                    fixedRecievedChargeKW += part.RequestResource(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, fixedPowerReqKW - fixedRecievedChargeKW);
-
-                recievedPowerKW = fixedRecievedChargeKW / fixedDeltaTime;
+                recievedPowerKW = consumeMegajoules(currentPowerReq * fixedDeltaTime /
+                    GameConstants.ecPerMJ, true, true, true) * GameConstants.ecPerMJ / fixedDeltaTime;
             }
             else
                 recievedPowerKW = 0;
 
             bool hasExtraBoiloff = initializationCountdown == 0 && powerReqKW > 0 && currentPowerReq > 0 && recievedPowerKW < currentPowerReq && previousRecievedPowerKW < previousPowerReq;
 
-            var boiloffReducuction = !hasExtraBoiloff ? boilOffRate : boilOffRate + (boilOffAddition * (1 - recievedPowerKW / currentPowerReq));
+            var boiloffReduction = !hasExtraBoiloff ? boilOffRate : boilOffRate + (boilOffAddition * (1 - recievedPowerKW / currentPowerReq));
 
-            boiloff = CheatOptions.IgnoreMaxTemperature ||  boiloffReducuction <= 0 ? 0 : boiloffReducuction * environmentBoiloff;
+            boiloff = CheatOptions.IgnoreMaxTemperature ||  boiloffReduction <= 0 ? 0 : boiloffReduction * environmentBoiloff;
 
-            if (boiloff > 0.0000000001)
+            if (boiloff > 1e-10)
             {
                 var boilOffAmount = boiloff * fixedDeltaTime;
 
@@ -296,7 +290,10 @@ namespace FNPlugin
 
         public override string GetInfo()
         {
-            return "<size=10>" + resourceName + " @ " + boilOffTemp + " K\nPower Requirements: " + (powerReqKW * 0.1).ToString("0.0") + " KW</size>";
+            double envMod = ((convectionMod <= -1.0) ? 0.0 : convectionMod + 1.0 /
+                (convectionMod + 1.0)) * Math.Max(0.0, 300.0 - boilOffTemp) / 300.0;
+            return string.Format("{0} @ {1:F1} K\nPower Requirements: {2:F1} KW", resourceName,
+                boilOffTemp, powerReqKW * 0.2 * powerReqMult * envMod);
         }
     }
 }

--- a/FNPlugin/Wasteheat/FNSolarPanelWasteHeatModule.cs
+++ b/FNPlugin/Wasteheat/FNSolarPanelWasteHeatModule.cs
@@ -1,6 +1,5 @@
 using FNPlugin.Constants;
 using FNPlugin.Power;
-using FNPlugin.Powermanagement;
 using FNPlugin.Resources;
 using System;
 using System.Collections.Generic;
@@ -22,23 +21,24 @@ namespace FNPlugin
     [KSPModule("Solar Panel Adapter")]
     class FNSolarPanelWasteHeatModule : ResourceSuppliableModule, ISolarPower
     {
-        [KSPField( guiActive = true,  guiName = "#LOC_KSPIE_SolarPanelWH_CurrentSolarPower", guiUnits = "#LOC_KSPIE_Reactor_megawattUnit", guiFormat= "F5")]//Current Solar Power
-        public double megaJouleSolarPowerSupply;
-        [KSPField(guiActive = true, guiName = "#LOC_KSPIE_SolarPanelWH_MaximumSolarPower", guiUnits = "#LOC_KSPIE_Reactor_megawattUnit", guiFormat = "F5")]//Maximum Solar Power
-        public double solarMaxSupply;
-        [KSPField(guiActive = false, guiName = "AU", guiFormat = "F0", guiUnits = " m")]
+        public const string GROUP = "FNSolarPanelWasteHeatModule";
+        public const string GROUP_TITLE = "Interstellar Solar Generator";
+
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActive = true, guiName = "#LOC_KSPIE_SolarPanelWH_CurrentSolarPower")]//Current Solar Power
+        public string mjSolarSupply;
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActive = true, guiName = "#LOC_KSPIE_SolarPanelWH_MaximumSolarPower")]//Maximum Solar Power
+        public string mjMaxSupply;
+        [KSPField(groupName = GROUP, groupDisplayName = GROUP_TITLE, guiActive = false, guiName = "AU", guiFormat = "F0", guiUnits = " m")]
         public double astronomicalUnit;
 
+        [KSPField]
+        public double solarMaxSupply;
         [KSPField]
         public string resourceName;
         [KSPField]
         public double solar_supply;
         [KSPField]
         public float chargeRate;
-        [KSPField]
-        public float efficiencyMult;
-        [KSPField]
-        public double _efficMult;
         [KSPField]
         public double sunAOA;
         [KSPField]
@@ -55,10 +55,6 @@ namespace FNPlugin
         [KSPField]
         public double scale = 1;
         [KSPField]
-        double maxSupply;
-        [KSPField]
-        double solarRate;
-        [KSPField]
         public double outputResourceRate;
         [KSPField]
         public double outputResourceCurrentRequest;
@@ -69,8 +65,8 @@ namespace FNPlugin
         ResourceType _outputType = 0;
         List<StarLight> _stars;
 
-        private BaseField _megaJouleSolarPowerSupplyField;
-        private BaseField _solarMaxSupplyField;
+        private BaseField _mjSolarSupplyField;
+        private BaseField _mjMaxSupplyField;
         private BaseField _fieldKerbalismNominalRate;
         private BaseField _fieldKerbalismPanelStatus;
 
@@ -85,8 +81,8 @@ namespace FNPlugin
         {
             if (state == StartState.Editor) return;
 
-            _megaJouleSolarPowerSupplyField = Fields[nameof(megaJouleSolarPowerSupply)];
-            _solarMaxSupplyField = Fields[nameof(solarMaxSupply)];
+            _mjSolarSupplyField = Fields[nameof(mjSolarSupply)];
+            _mjMaxSupplyField = Fields[nameof(mjMaxSupply)];
 
             if (part.Modules.Contains("SolarPanelFixer"))
             {
@@ -170,11 +166,11 @@ namespace FNPlugin
 
         public override void OnUpdate()
         {
-            if (_megaJouleSolarPowerSupplyField != null)
-                _megaJouleSolarPowerSupplyField.guiActive = solarMaxSupply > 0;
+            if (_mjSolarSupplyField != null)
+                _mjSolarSupplyField.guiActive = solarMaxSupply > 0;
 
-            if (_solarMaxSupplyField != null)
-                _solarMaxSupplyField.guiActive = solarMaxSupply > 0;
+            if (_mjMaxSupplyField != null)
+                _mjMaxSupplyField.guiActive = solarMaxSupply > 0;
         }
 
         public override void OnFixedUpdateResourceSuppliable(double fixedDeltaTime)
@@ -207,15 +203,13 @@ namespace FNPlugin
             if (_outputType == ResourceType.other) return;
 
             chargeRate = _solarPanel.chargeRate;
-            efficiencyMult = _solarPanel.efficiencyMult;
-            _efficMult = _solarPanel._efficMult;
 
-            calculatedEfficency = _solarPanel._efficMult > 0
-                ? _solarPanel._efficMult
-                : _solarPanel.temperatureEfficCurve.Evaluate((float)part.skinTemperature) * _solarPanel.timeEfficCurve.Evaluate((float)((Planetarium.GetUniversalTime() - _solarPanel.launchUT) * 1.15740740740741E-05)) * _solarPanel.efficiencyMult;
+            double age = (Planetarium.GetUniversalTime() - _solarPanel.launchUT) * 1.15740740740741E-05;
+            calculatedEfficency = _solarPanel._efficMult > 0 ? _solarPanel._efficMult :
+                _solarPanel.temperatureEfficCurve.Evaluate((float)part.skinTemperature) *
+                _solarPanel.timeEfficCurve.Evaluate((float)age) * _solarPanel.efficiencyMult;
 
-            maxSupply = 0;
-            solarRate = 0;
+            double maxSupply = 0.0, solarRate = 0.0;
             sunAOA = 0;
             CalculateSolarFlowRate(calculatedEfficency / scale, ref maxSupply, ref solarRate);
 
@@ -232,10 +226,11 @@ namespace FNPlugin
             }
 
             // provide power to supply manager
-            solar_supply = _outputType == ResourceType.megajoule ? solarRate : solarRate * 0.001;
-            solarMaxSupply = _outputType == ResourceType.megajoule ? maxSupply : maxSupply * 0.001;
+            solar_supply = _outputType == ResourceType.megajoule ? solarRate : solarRate / GameConstants.ecPerMJ;
+            solarMaxSupply = _outputType == ResourceType.megajoule ? maxSupply : maxSupply / GameConstants.ecPerMJ;
 
-            megaJouleSolarPowerSupply = supplyFNResourcePerSecondWithMax(solar_supply, solarMaxSupply, ResourceManager.FNRESOURCE_MEGAJOULES);
+            mjSolarSupply = PluginHelper.getFormattedPowerString(supplyFNResourcePerSecondWithMax(solar_supply, solarMaxSupply, ResourceManager.FNRESOURCE_MEGAJOULES));
+            mjMaxSupply = PluginHelper.getFormattedPowerString(solarMaxSupply);
         }
 
         private void CalculateSolarFlowRate(double efficiency, ref double maximumSupply, ref double solarPowerRate)

--- a/FNPlugin/Wasteheat/FNSolarPanelWasteHeatModule.cs
+++ b/FNPlugin/Wasteheat/FNSolarPanelWasteHeatModule.cs
@@ -1,4 +1,6 @@
+using FNPlugin.Constants;
 using FNPlugin.Power;
+using FNPlugin.Powermanagement;
 using FNPlugin.Resources;
 using System;
 using System.Collections.Generic;
@@ -130,8 +132,8 @@ namespace FNPlugin
                 _resourceBuffers = new ResourceBuffers();
                 _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.FNRESOURCE_MEGAJOULES));
                 _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE));
-                _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_MEGAJOULES, _outputType == ResourceType.electricCharge ? _solarPanel.chargeRate * 0.001f : _solarPanel.chargeRate);
-                _resourceBuffers.UpdateVariable(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, _outputType == ResourceType.electricCharge ? _solarPanel.chargeRate : _solarPanel.chargeRate * 1000);
+                _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_MEGAJOULES, _outputType == ResourceType.electricCharge ? _solarPanel.chargeRate / GameConstants.ecPerMJ : _solarPanel.chargeRate);
+                _resourceBuffers.UpdateVariable(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, _outputType == ResourceType.electricCharge ? _solarPanel.chargeRate : _solarPanel.chargeRate * GameConstants.ecPerMJ);
                 _resourceBuffers.Init(part);
             }
 

--- a/GameData/WarpPlugin/Localization/Parts/en-us.cfg
+++ b/GameData/WarpPlugin/Localization/Parts/en-us.cfg
@@ -282,7 +282,7 @@
 		#LOC_KSPIE_RectennaUpgrade_descr = When researched, increases the efficiency of Rectenna power receivers.
 
 		#LOC_KSPIE_KspiSolarBlanket_title = Blanket Photovoltaic Solar Power Receiver
-		#LOC_KSPIE_KspiSolarBlanket_descr = This enormous photovoltaic solar power receiver weighs less than blanket thermal receivers, but is less efficient at frequencies outside the near infrared spectrum. It cannot be retracted once deployed, and solar energy received by this panel cannot be used by beamed power transmitters. It is also unable to placate angry environmentalists protesting the global warming effects of rocket exhaust.
+		#LOC_KSPIE_KspiSolarBlanket_descr = This enormous photovoltaic solar power receiver weighs less than blanket thermal receivers, but is less efficient at frequencies outside the near infrared spectrum and is unable to retract once deployed. It is unable to placate angry environmentalists protesting the global warming effects of rocket exhaust.
 		#LOC_KSPIE_KspiSolarBlanket_tags = charge deploy e/c elect energy extend fold generate light panel photo power retract sun track unfold volt watt advanced
 		#LOC_KSPIE_SolarPhotovoltaicUpgrade_title = Solar Photovoltaic Upgrade
 		#LOC_KSPIE_SolarPhotovoltaicUpgrade_descr = When researched, increases the efficiency of Solar Photovoltaic power receivers.
@@ -338,19 +338,19 @@
 		#LOC_KSPIE_SolarMoltenSaltReceiver_tags = solar beamed power receiver dielectric integrated generator
 
 		#LOC_KSPIE_KspiBlanketThermophotovoltaic_title = Blanket Thermophotovoltaic Receiver
-		#LOC_KSPIE_KspiBlanketThermophotovoltaic_descr = A typographical error on an order for Deployable Thermophotovoltaic Receivers led to a massive excess of receiver material. We packed them into a massive blanket array that can receive power at any non-ionizing wavelength, allowing full utilization of solar radiation. Despite the high mass, this array is unable to retract or transmit power. Solar energy received by this panel cannot be used by beamed power transmitters.
+		#LOC_KSPIE_KspiBlanketThermophotovoltaic_descr = A typographical error on an order for Deployable Thermophotovoltaic Receivers led to a massive excess of receiver material. We packed them into a massive blanket array that can receive power at any non-ionizing wavelength, allowing full utilization of solar radiation. Despite the high mass, this array is unable to retract or transmit power.
 		#LOC_KSPIE_KspiBlanketThermophotovoltaic_tags = charge deploy e/c elect energ extend fold generat light panel photo power retract sun track unfold volt watt advanced
 		#LOC_KSPIE_ThermophotovoltaicUpgrade_title = Thermal Photovoltaic Upgrade
 		#LOC_KSPIE_ThermophotovoltaicUpgrade_descr = When researched, increases the efficiency of Thermophotovoltaic power receivers.
 
 		#LOC_KSPIE_CircularThermophotovoltaicReceiver_title = Circular Thermophotovoltaic Receivers
-		#LOC_KSPIE_CircularThermophotovoltaicReceiver_descr = A circular thermophotovoltaic receiver which produces electricity from solar or any non-ionizing beamed power. Solar energy received by this panel cannot be used by beamed power transmitters.
+		#LOC_KSPIE_CircularThermophotovoltaicReceiver_descr = A circular thermophotovoltaic receiver which produces electricity from solar or any non-ionizing beamed power. For its size, it has a high maximum power capacity but a relatively low efficiency.
 
 		#LOC_KSPIE_DeployableThermalReceiver_title = Deployable Thermophotovoltaic Receiver
-		#LOC_KSPIE_DeployableThermalReceiver_descr = A large foldable thermophotovoltaic receiver which can receive power at any non-ionizing wavelength, allowing full utilization of solar radiation. Solar energy received by this panel cannot be used by beamed power transmitters.
+		#LOC_KSPIE_DeployableThermalReceiver_descr = A large foldable thermophotovoltaic receiver which can receive large amounts of power at any non-ionizing wavelength, allowing full utilization of solar radiation. It is even able to retract due to angry protests from customers of the Blanket Thermophotovolatic Receiver. However, it is heavier and less efficient than dedicated photovoltaic or phased array receivers.
 
 		#LOC_KSPIE_PivotedThermoPhotovoltaicReceiver_title = Double Pivoted Thermophotovoltaic Receiver
-		#LOC_KSPIE_PivotedThermoPhotovoltaicReceiver_descr = This deployable thermophotovoltaic receiver can receive beamed power or solar energy at any non-ionizing wavelength. It can pivot within a 300 degree angle, but cannot operate while moving in an atmosphere. Solar energy received by this panel cannot be used by beamed power transmitters.
+		#LOC_KSPIE_PivotedThermoPhotovoltaicReceiver_descr = This deployable thermophotovoltaic receiver can receive beamed power or solar energy at any non-ionizing wavelength. It can pivot within a 300 degree angle to track the source, but cannot operate while moving in an atmosphere.
 		#LOC_KSPIE_PivotedThermoPhotovoltaicReceiver_tags = microwave infrared receiver rectenna DragonTech
 
 		#LOC_KSPIE_microwaveSphereReceiver_title = Dual Mode Thermal Spherical Receiver

--- a/Redist/GameConstants.cs
+++ b/Redist/GameConstants.cs
@@ -53,6 +53,7 @@
         public const float MaxThermalNozzleIsp = 2997.13f;
         public const double EngineHeatProduction = 1000;
         public const double AirflowHeatMultiplier = 1;
+        public const double ecPerMJ = 1000.0;
 
         public const int KEBRIN_HOURS_DAY = 8;
         public const int SECONDS_IN_HOUR = 3600;


### PR DESCRIPTION
Add info sections for KSPIE solar panel adapters and improve their display format. Remove outdated warning about the large solar and thermophotovoltaic receivers being unusable for beamed power generation. 

Remove duplicate code and constants used for charging many types of items and unify them into one method on `ResourceSuppliableModule`.