### PR TITLE
Fix waste heat generation on Near Future reactors

### DIFF
--- a/FNPlugin/Beamedpower/BeamedPowerReceiver.cs
+++ b/FNPlugin/Beamedpower/BeamedPowerReceiver.cs
@@ -1157,7 +1157,7 @@ namespace FNPlugin
                     _resourceBuffers.AddConfiguration(new WasteHeatBufferConfig(wasteHeatMultiplier * wasteHeatModifier, 2.0e+5));
                     _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.FNRESOURCE_THERMALPOWER, thermalPowerBufferMult));
                     _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.FNRESOURCE_MEGAJOULES));
-                    _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE));
+                    _resourceBuffers.AddConfiguration(new ResourceBuffers.TimeBasedConfig(ResourceManager.STOCK_RESOURCE_ELECTRICCHARGE, 100.0));
                     _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_WASTEHEAT, part.mass);
                     _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_THERMALPOWER, StableMaximumReactorPower);
                     _resourceBuffers.UpdateVariable(ResourceManager.FNRESOURCE_MEGAJOULES, StableMaximumReactorPower);

--- a/GameData/WarpPlugin/Parts/BeamedPower/BeamGenerators/FreeElectronLaser/FreeElectronLaser2.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/BeamGenerators/FreeElectronLaser/FreeElectronLaser2.cfg
@@ -612,7 +612,7 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
+		amount = 200
 		maxAmount = 200
 	}
 }

--- a/GameData/WarpPlugin/Parts/BeamedPower/BeamGenerators/Gyrotron/Gyrotron.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/BeamGenerators/Gyrotron/Gyrotron.cfg
@@ -125,7 +125,7 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
+		amount = 200
 		maxAmount = 200
 	}
 }

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/InlinePhasedArray/InlinePhasedArray.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/InlinePhasedArray/InlinePhasedArray.cfg
@@ -56,8 +56,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 1000
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/InlineWrappedPhasedArray/InlineWrappedPhasedArray.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/InlineWrappedPhasedArray/InlineWrappedPhasedArray.cfg
@@ -42,8 +42,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 1000
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/PivotedPhasedArray/MicrowavePivotRectenna.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/PivotedPhasedArray/MicrowavePivotRectenna.cfg
@@ -39,8 +39,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/RadialPhasedArray/MicroWaveR_Radial.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/RadialPhasedArray/MicroWaveR_Radial.cfg
@@ -387,8 +387,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 200
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/SpherePhasedArray/SpherePhasedArray.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/SpherePhasedArray/SpherePhasedArray.cfg
@@ -46,8 +46,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/phasedArray1/deployablePhasedArray.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/phasedArray1/deployablePhasedArray.cfg
@@ -48,8 +48,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 2500
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/phasedArray2/receiverNew.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/PhasedArray/phasedArray2/receiverNew.cfg
@@ -47,8 +47,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 50
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Rectenna/BlanketRectennaReceiver/blanket_rectenna.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Rectenna/BlanketRectennaReceiver/blanket_rectenna.cfg
@@ -397,8 +397,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 63
-		maxAmount = 63
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Rectenna/CircularRectennaReceiver/CircularRectennaPanel.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Rectenna/CircularRectennaReceiver/CircularRectennaPanel.cfg
@@ -409,8 +409,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Solar/BlanketPhotovoltaicReceiver/solarpanel-blanket-1.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Solar/BlanketPhotovoltaicReceiver/solarpanel-blanket-1.cfg
@@ -313,8 +313,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 63
-		maxAmount = 63
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Solar/CircularSolarPhotovoltaicReceiver/CircularPanel.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Solar/CircularSolarPhotovoltaicReceiver/CircularPanel.cfg
@@ -313,8 +313,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 20
-		maxAmount = 20
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Solar/TriangleReceiver/TriangleSolarPanel.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Solar/TriangleReceiver/TriangleSolarPanel.cfg
@@ -294,8 +294,8 @@
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 60
-		maxAmount = 60
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/FoldingThermalDish/part.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/FoldingThermalDish/part.cfg
@@ -239,8 +239,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 20
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/InlineThermalReceiverPanel/MW_TR_DI.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/InlineThermalReceiverPanel/MW_TR_DI.cfg
@@ -43,8 +43,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 1000
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/MicrowaveThermalPowerReceiver/MTER-S.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/MicrowaveThermalPowerReceiver/MTER-S.cfg
@@ -59,8 +59,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/MicrowaveThermalPowerReceiverMk2/MTPRmk2.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/MicrowaveThermalPowerReceiverMk2/MTPRmk2.cfg
@@ -83,8 +83,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	// Modules
@@ -110,8 +110,8 @@ PART
 		maximumElectricPower = 10000
 		maximumThermalPower = 10000
 
-        	supportedPropellantAtoms = 511
-       		supportedPropellantTypes = 127
+		supportedPropellantAtoms = 511
+		supportedPropellantTypes = 127
 
 		engineHeatProductionMult = 0.5 			// reduce thermal engine heat production by 50%		
 		thermalProcessingModifier = 0.5

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishAluminium/SIGINT.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishAluminium/SIGINT.cfg
@@ -82,8 +82,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishAluminium/SIGINT_End.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishAluminium/SIGINT_End.cfg
@@ -77,8 +77,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINT.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINT.cfg
@@ -79,8 +79,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINTEnd.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINTEnd.cfg
@@ -79,8 +79,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINT_End.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermal/OversizeFoldingDishGold/SIGINT_End.cfg
@@ -81,8 +81,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/BlanketThermophotovoltaicReceiver/blanket_rectenna.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/BlanketThermophotovoltaicReceiver/blanket_rectenna.cfg
@@ -236,8 +236,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 63
-		maxAmount = 63
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/CircularThermophotovoltaicReceiver/CircularPanel.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/CircularThermophotovoltaicReceiver/CircularPanel.cfg
@@ -254,8 +254,8 @@ PART
 	RESOURCE
 	{
  		name = ElectricCharge
- 		amount = 250
- 		maxAmount = 250
+ 		amount = 100
+ 		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/DeployableThermophotovoltaicReceiver/DeployableThermalReceiver.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/DeployableThermophotovoltaicReceiver/DeployableThermalReceiver.cfg
@@ -53,8 +53,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 2500
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/PivotedThermoPhotovoltaicReceiver/PivotedThermoPhotovoltaicReceiver.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Thermophotovoltaic/PivotedThermoPhotovoltaicReceiver/PivotedThermoPhotovoltaicReceiver.cfg
@@ -37,8 +37,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MediumDish/BT2502.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MediumDish/BT2502.cfg
@@ -56,8 +56,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 10
-		maxAmount = 10
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MicrowaveRectenna/MicrowaveRectenna.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MicrowaveRectenna/MicrowaveRectenna.cfg
@@ -474,8 +474,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MicrowaveTransducer/MicroWaveTransducer.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/MicrowaveTransducer/MicroWaveTransducer.cfg
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/OversizedMicrowaveDishTransciever/SIGINT.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Transmitters/OversizedMicrowaveDishTransciever/SIGINT.cfg
@@ -79,8 +79,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 1000
+		amount = 100
+		maxAmount = 100
 	}
 
 	MODULE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Ultraviolet/BlanketUltravoiletPhotovoltaicReceiver/ultravioletpanel-blanket-1.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Ultraviolet/BlanketUltravoiletPhotovoltaicReceiver/ultravioletpanel-blanket-1.cfg
@@ -341,8 +341,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 63
-		maxAmount = 63
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/Ultraviolet/CircularUltravioletPhotovoltaicReceiver/CircularPanel.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/Ultraviolet/CircularUltravioletPhotovoltaicReceiver/CircularPanel.cfg
@@ -355,8 +355,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/XRay/DeployableXrayReceiver/DeployableXrayReceiver.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/XRay/DeployableXrayReceiver/DeployableXrayReceiver.cfg
@@ -52,8 +52,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 0
-		maxAmount = 2500
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/XRay/InlineXRayReceiverPanel/InlineSolarReceiver.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/XRay/InlineXRayReceiverPanel/InlineSolarReceiver.cfg
@@ -42,8 +42,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 2500
-		maxAmount = 2500
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE

--- a/GameData/WarpPlugin/Parts/BeamedPower/XRay/PivotedXRayReceiver/DoublePivotedXRayReceiver.cfg
+++ b/GameData/WarpPlugin/Parts/BeamedPower/XRay/PivotedXRayReceiver/DoublePivotedXRayReceiver.cfg
@@ -389,8 +389,8 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 250
-		maxAmount = 250
+		amount = 100
+		maxAmount = 100
 	}
 
 	RESOURCE


### PR DESCRIPTION
Fix waste heat generation on throttled down Near Future reactors. Removed the EC resource buffer configuration on NF reactors as it was voiding huge amounts of energy on some parts (example: MKS 'Duna' Power Distribution Unit has a default storage of 50000 EC, but KSPIE tried to set it to 1 EC during warp).

Unify all beamed power receivers to 100 EC stored.