### PR TITLE
Fix for thermal and charged particle power taking longer to fill when time warping.

### DIFF
--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1560,11 +1560,11 @@ namespace FNPlugin.Reactors
                 var maximumChargedRequestRatio = Math.Min(maximumChargedPropulsionRatio + maximumChargedGeneratorRatio, 1);
 
                 var finalCurrentThermalRequestRatio = Math.Max(currentThermalRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * 0.001 * ThermalPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ThermalPowerRatio);
                 var finalCurrentChargedRequestRatio = Math.Max(currentChargedRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * 0.001 * ChargedPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ChargedPowerRatio);
 
-                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * 0.001, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
+                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * timeWarpFixedDeltaTime / 20, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
                 var maximumReactorRequestRatio = Math.Max(maximumThermalRequestRatio, maximumChargedRequestRatio);
 
                 var powerAccessModifier = Math.Max(


### PR DESCRIPTION
Currently, if a reactor's thermal or charged particle power is not full and power demands are low, it will produce enough to fill 0.1% of its unfilled capacity per tick.  This does not respect time warp: the same percentage of the bar will fill in a given amount of real-time seconds regardless of the current time warp factor.  This results in reactors wasting additional fuel, since reactors consume more fuel while warming up like this, and time warping makes it take longer to warm up completely.

This change makes the bar percentage filled per tick scale with time warp in order to offset this, and with the exception of the effects of other existing time warp related bugs in the reactor code,  it should take the same amount of game time and reactor fuel for a reactor to fill its capacity of thermal power and/or charged particles.  The base speed where it gets filled (at 1x speed) should be the same.