### PR TITLE
Fixed antimatter containers consuming power proportional to time warp

### DIFF
--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1560,11 +1560,11 @@ namespace FNPlugin.Reactors
                 var maximumChargedRequestRatio = Math.Min(maximumChargedPropulsionRatio + maximumChargedGeneratorRatio, 1);
 
                 var finalCurrentThermalRequestRatio = Math.Max(currentThermalRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * 0.001 * ThermalPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ThermalPowerRatio);
                 var finalCurrentChargedRequestRatio = Math.Max(currentChargedRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * 0.001 * ChargedPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ChargedPowerRatio);
 
-                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * 0.001, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
+                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * timeWarpFixedDeltaTime / 20, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
                 var maximumReactorRequestRatio = Math.Max(maximumThermalRequestRatio, maximumChargedRequestRatio);
 
                 var powerAccessModifier = Math.Max(

--- a/FNPlugin/Storage/AntimatterStorageTank.cs
+++ b/FNPlugin/Storage/AntimatterStorageTank.cs
@@ -692,8 +692,8 @@ namespace FNPlugin.Storage
 
             if (effectivePowerNeeded > 0.0)
             {
-                double powerRequest = (chargeStatus >= maxCharge ? 1.0 : 2.0) * effectivePowerNeeded * TimeWarp.fixedDeltaTime;
-                double chargeToAdd = ConsumeMegawatts(powerRequest / GameConstants.ecPerMJ, true, true, true) * GameConstants.ecPerMJ / effectivePowerNeeded;
+                double powerRequest = (chargeStatus >= maxCharge ? 1.0 : 2.0) * effectivePowerNeeded;
+                double chargeToAdd = ConsumeMegawatts(powerRequest / GameConstants.ecPerMJ, true, true, true) * GameConstants.ecPerMJ / effectivePowerNeeded * TimeWarp.fixedDeltaTime;
                 chargeStatus += chargeToAdd;
 
                 if (chargeToAdd >= TimeWarp.fixedDeltaTime)


### PR DESCRIPTION
Under the current build, antimatter containers consume more power proportional to the time warp factor.  This is most likely the underlying issue for reports of excessive power consumption under time warp.  Under high time warp factors, this results in large tanks of positrons consuming what would be several decades of fuel in a few in-game hours.  Apparently the power draw was being multiplied by the time warp factor.  Testing showed that removing this made the generator think its charge was too low to warp above 100x, but multiplying the amount of stored charge added appears to have fixed this.

This also includes an apparent balance change, since at normal speed power was being drawn 50 times slower.  After the fix, power is now drawn at the rate listed on the part attributes listed in-game.  A KSPIE SAGE engine, for example, will now consume 60 KW of power to maintain containment at all time warp speeds, and at the maximum storage upgrade level should be able to idle for about 71 years with its fuel with a reasonably efficient power generator attached.