### PR TITLE
Revert previous reactor fix, add new fix

### DIFF
--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1560,11 +1560,11 @@ namespace FNPlugin.Reactors
                 var maximumChargedRequestRatio = Math.Min(maximumChargedPropulsionRatio + maximumChargedGeneratorRatio, 1);
 
                 var finalCurrentThermalRequestRatio = Math.Max(currentThermalRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ThermalPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * 0.001 * ThermalPowerRatio);
                 var finalCurrentChargedRequestRatio = Math.Max(currentChargedRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ChargedPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * 0.001 * ChargedPowerRatio);
 
-                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * timeWarpFixedDeltaTime / 20, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
+                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * 0.001, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
                 var maximumReactorRequestRatio = Math.Max(maximumThermalRequestRatio, maximumChargedRequestRatio);
 
                 var powerAccessModifier = Math.Max(

--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1936,8 +1936,8 @@ namespace FNPlugin.Reactors
             var plasmaThrottleIsGrowing = _currentGeneratorPlasmaEnergyRequestRatio > storedGeneratorPlasmaEnergyRequestRatio;
             var chargedThrottleIsGrowing = _currentGeneratorChargedEnergyRequestRatio > storedGeneratorChargedEnergyRequestRatio;
 
-            var fixedReactorSpeedMultiplier = ReactorSpeedMult * timeWarpFixedDeltaTime;
-            var minimumAcceleration = timeWarpFixedDeltaTime * timeWarpFixedDeltaTime;
+            var fixedReactorSpeedMultiplier = ReactorSpeedMult * timeWarpFixedDeltaTime * 50;
+            var minimumAcceleration = timeWarpFixedDeltaTime * timeWarpFixedDeltaTime * 50;
 
             var thermalAccelerationReductionRatio = thermalThrottleIsGrowing
                 ? storedGeneratorThermalEnergyRequestRatio <= 0.5 ? 1 : minimumAcceleration + (1 - storedGeneratorThermalEnergyRequestRatio) / 0.5

--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1560,11 +1560,11 @@ namespace FNPlugin.Reactors
                 var maximumChargedRequestRatio = Math.Min(maximumChargedPropulsionRatio + maximumChargedGeneratorRatio, 1);
 
                 var finalCurrentThermalRequestRatio = Math.Max(currentThermalRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * 0.001 * ThermalPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ThermalPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ThermalPowerRatio);
                 var finalCurrentChargedRequestRatio = Math.Max(currentChargedRequestRatio,
-                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * 0.001 * ChargedPowerRatio);
+                    (1 - GetResourceBarFraction(ResourceSettings.Config.ChargedPowerInMegawatt)) * timeWarpFixedDeltaTime / 20 * ChargedPowerRatio);
 
-                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * 0.001, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
+                var finalReactorRequestRatio = Math.Max(vessel.ctrlState.mainThrottle * timeWarpFixedDeltaTime / 20, Math.Max(finalCurrentThermalRequestRatio, finalCurrentChargedRequestRatio)) ;
                 var maximumReactorRequestRatio = Math.Max(maximumThermalRequestRatio, maximumChargedRequestRatio);
 
                 var powerAccessModifier = Math.Max(


### PR DESCRIPTION
This reverts the reactor fix in #689 since it was causing several other bugs that were missed during testing (filling thermal power faster uses more fuel than it should, for starters).  This bug is likely a symptom of larger issues in the reactor code which may not be solvable without a larger rewrite.

This also fixes a reactor bug that predates this change, where some reactors were susceptible to drawing far more power than they should under low time warp settings.  