### PR TITLE
Add Waterfall support to RCS thrusters

### DIFF
--- a/FNPlugin/Propulsion/ElectricRCSController.cs
+++ b/FNPlugin/Propulsion/ElectricRCSController.cs
@@ -333,6 +333,9 @@ namespace FNPlugin.Propulsion
 
             _powerConsumptionStrField.guiActive = _attachedRcs != null && rcsIsOn;
 
+            if (part.Modules.Contains("ModuleWaterfallFX"))
+                WaterfallIntegration.RCSPower(part, _attachedRcs.thrusterTransformName, powerEnabled);
+
             if (_rcsStates == null) return;
 
             bool rcsPartActive = false;

--- a/FNPlugin/Propulsion/WaterfallIntegration.cs
+++ b/FNPlugin/Propulsion/WaterfallIntegration.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using Waterfall;
+
+namespace FNPlugin.Propulsion
+{
+    // This class exists solely as a shield for referencing Waterfall, so it can be referenced without spamming errors if it isn't installed.
+    // This should be the only class referencing Waterfall, and you should ALWAYS verify that a ModuleWaterfallFX is present before calling
+    // anything in this class -- a quick way to do this is if (part.Modules.Contains("ModuleWaterfallFX")) 
+    public class WaterfallIntegration
+    {
+        public static void RCSPower(Part part, string thrusterTransform, bool rcsPowered)
+        {
+            foreach (ModuleWaterfallFX module in part.FindModulesImplementing<ModuleWaterfallFX>())
+                // HeavyRCS has two effects that are independently powered, this distinguishes them by their transform
+                if(module.FX.First().parentName == thrusterTransform)
+                    foreach (WaterfallController controller in module.Controllers)                    
+                        if (controller.GetType() == typeof(CustomController) && controller.name == "rcsPower")
+                        {
+                            // for some reason controller.SetOverride(true) doesn't work
+                            // this also takes over the override from the effect editor UI,
+                            // so you'll have to manually alter whatever drives your controller
+                            controller.overridden = true;
+                            if (rcsPowered) controller.SetOverrideValue(1);
+                            else controller.SetOverrideValue(0);                        
+                        }            
+        }
+    }
+}

--- a/GameData/WarpPlugin/Parts/Control/CrossArcjet/CrossArcjet.cfg
+++ b/GameData/WarpPlugin/Parts/Control/CrossArcjet/CrossArcjet.cfg
@@ -130,6 +130,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 
 		TEMPLATE
 		{

--- a/GameData/WarpPlugin/Parts/Control/CrossArcjet/CrossArcjet.cfg
+++ b/GameData/WarpPlugin/Parts/Control/CrossArcjet/CrossArcjet.cfg
@@ -49,7 +49,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_small
 				transformName = RCSthruster
@@ -108,4 +108,39 @@ PART
 		maxIsp = 2000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSthruster
+			position = -0.025,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+
 }

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-45d.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-45d.cfg
@@ -131,14 +131,18 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use
 			templateName = waterfall-interstellar-rcs-arcjet-1
 			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
 			overrideParentTransform = RCSThrust
-			position = 0,-0.3,0
+			position = 0,-0.1,0
 			rotation = 0, 0, 180
 			scale = 1, 1, 1
 		}

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-45d.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-45d.cfg
@@ -49,7 +49,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThrust
@@ -108,6 +108,40 @@ PART
 		maxIsp = 2000 			// Max powered Isp for Hydrogen
 		minIsp = 250  			// Max unpowered Isp for Hydrogen
 		bufferMult = 5
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThrust
+			position = 0,-0.3,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
 	}
 }
 

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-90d.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-90d.cfg
@@ -50,7 +50,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThrust
@@ -111,6 +111,41 @@ PART
 		scaleFactors = 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8, 12, 16, 24, 32
 		scaleNames = 50%, 75%, 100%, 150%, 200%, 300%, 400%, 600%, 800%, 1200%, 1600%, 2400%, 3200%
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThrust
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+}
 }
 
 

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-90d.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-90d.cfg
@@ -133,14 +133,18 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use
 			templateName = waterfall-interstellar-rcs-arcjet-1
 			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
 			overrideParentTransform = RCSThrust
-			position = 0,0,0
+			position = 0,-0.075,0
 			rotation = 0, 0, 180
 			scale = 1, 1, 1
 		}

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-perpindicular.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-perpindicular.cfg
@@ -50,7 +50,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThrust
@@ -111,4 +111,39 @@ PART
 		scaleFactors = 0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8, 12, 16, 24, 32
 		scaleNames = 50%, 100%, 150%, 200%, 300%, 400%, 600%, 800%, 1200%, 1600%, 2400%, 3200%
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThrust
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+}
 }

--- a/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-perpindicular.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HWRCS/RCS-perpindicular.cfg
@@ -133,14 +133,18 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use
 			templateName = waterfall-interstellar-rcs-arcjet-1
 			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
 			overrideParentTransform = RCSThrust
-			position = 0,0,0
+			position = 0,-0.1,0
 			rotation = 0, 0, 180
 			scale = 1, 1, 1
 		}

--- a/GameData/WarpPlugin/Parts/Control/HeavyRCS/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HeavyRCS/part.cfg
@@ -47,7 +47,7 @@ PART
 				pitch = 1.0 1.5
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_small
 				transformName = RCSThruster
@@ -74,7 +74,7 @@ PART
 				pitch = 1.0 1.5
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_big
 				transformName = RCSTransform
@@ -155,4 +155,75 @@ PART
 		maxIsp = 1000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+			thrusterTransformName = RCSThruster
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThruster
+			position = 0,-0.03,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX2
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+			thrusterTransformName = RCSTransform
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSTransform
+			position = 0,-0.02,0
+			rotation = 0, 0, 180
+			scale = 2, 2, 2
+		}
+	}
+
 }

--- a/GameData/WarpPlugin/Parts/Control/HeavyRCS/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/HeavyRCS/part.cfg
@@ -178,14 +178,19 @@ PART
 			linkedTo = rcs
 			thrusterTransformName = RCSThruster
 		}
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 
 		TEMPLATE
 		{
 			// This is the name of the template to use
-			templateName = waterfall-interstellar-rcs-resistojet-1
+			templateName = waterfall-interstellar-rcs-resistojet-heavy
 			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
 			overrideParentTransform = RCSThruster
-			position = 0,-0.03,0
+			position = 0,-0.05,0
 			rotation = 0, 0, 180
 			scale = 1, 1, 1
 		}
@@ -213,16 +218,21 @@ PART
 			linkedTo = rcs
 			thrusterTransformName = RCSTransform
 		}
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 
 		TEMPLATE
 		{
 			// This is the name of the template to use
-			templateName = waterfall-interstellar-rcs-resistojet-1
+			templateName = waterfall-interstellar-rcs-resistojet-heavy
 			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
 			overrideParentTransform = RCSTransform
-			position = 0,-0.02,0
+			position = 0,-0.05,0
 			rotation = 0, 0, 180
-			scale = 2, 2, 2
+			scale = 1.75, 1.75, 1.75
 		}
 	}
 

--- a/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCS.cfg
+++ b/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCS.cfg
@@ -48,7 +48,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThrust
@@ -240,4 +240,39 @@ PART
 		boilOffBase	= 	2000
 		boilOffAddition =	8.97215e-5
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThrust
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+}
 }

--- a/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCS.cfg
+++ b/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCS.cfg
@@ -262,7 +262,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCSpass.cfg
+++ b/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCSpass.cfg
@@ -148,7 +148,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCSpass.cfg
+++ b/GameData/WarpPlugin/Parts/Control/InlineRCS/InlineRCSpass.cfg
@@ -48,7 +48,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThrust
@@ -126,4 +126,39 @@ PART
 		name = ModuleConnectedLivingSpace
 		passable = true
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThrust
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
+	}
+}
 }

--- a/GameData/WarpPlugin/Parts/Control/NBrcs5block/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/NBrcs5block/part.cfg
@@ -61,7 +61,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSthruster
@@ -117,5 +117,39 @@ PART
 		partMass = 0.1			// mass visible in the VAB 
 		maxIsp = 1000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSthruster
+			position = 0,0.05,0
+			rotation = 0, 0, 180
+		scale = 0.75, 1, 0.75
+		}
 	}
 }

--- a/GameData/WarpPlugin/Parts/Control/NBrcs5block/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/NBrcs5block/part.cfg
@@ -140,7 +140,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/NBrcsCorner/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/NBrcsCorner/part.cfg
@@ -140,7 +140,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/NBrcsCorner/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/NBrcsCorner/part.cfg
@@ -61,7 +61,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSthruster
@@ -117,5 +117,39 @@ PART
 		partMass = 0.1			// mass visible in the VAB 
 		maxIsp = 1000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSthruster
+			position = 0,0.05,0
+			rotation = 0, 0, 180
+			scale = 0.75, 1, 0.75
+		}
 	}
 }

--- a/GameData/WarpPlugin/Parts/Control/OmniArcjetRcs/OmniArcjetRcs.cfg
+++ b/GameData/WarpPlugin/Parts/Control/OmniArcjetRcs/OmniArcjetRcs.cfg
@@ -141,7 +141,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/OmniArcjetRcs/OmniArcjetRcs.cfg
+++ b/GameData/WarpPlugin/Parts/Control/OmniArcjetRcs/OmniArcjetRcs.cfg
@@ -58,7 +58,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSThruster
@@ -118,5 +118,39 @@ PART
 		maxIsp = 2000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
 		bufferMult = 20
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSThruster
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
 	}
 }

--- a/GameData/WarpPlugin/Parts/Control/RCSTank/serviceModule2.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RCSTank/serviceModule2.cfg
@@ -317,7 +317,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/RCSTank/serviceModule2.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RCSTank/serviceModule2.cfg
@@ -58,7 +58,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCS
@@ -294,6 +294,40 @@ PART
 		boilOffMultiplier =	1
 		boilOffBase	= 	1000
 		boilOffAddition =	8.97215e-5
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCS
+			position = 0,-0.1,0
+			rotation = 0, 0, 180
+			scale = 0.35, 1, 0.35
+		}
 	}
 }
 

--- a/GameData/WarpPlugin/Parts/Control/RCSTankSM500/RCSTankSM500.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RCSTankSM500/RCSTankSM500.cfg
@@ -49,7 +49,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = TR
@@ -282,5 +282,39 @@ PART
 		boilOffMultiplier =	1
 		boilOffBase	= 	1000
 		boilOffAddition =	8.97215e-5
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-arcjet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = TR
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 1, 1, 1
+		}
 	}
 }

--- a/GameData/WarpPlugin/Parts/Control/RCSTankSM500/RCSTankSM500.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RCSTankSM500/RCSTankSM500.cfg
@@ -305,7 +305,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/RetractablerRcsBlock/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RetractablerRcsBlock/part.cfg
@@ -59,7 +59,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSthruster
@@ -117,4 +117,39 @@ PART
 		maxIsp = 1000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
 	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSthruster
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 0.5, 1, 0.5
+		}
+	}
+
 }

--- a/GameData/WarpPlugin/Parts/Control/RetractablerRcsBlock/part.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RetractablerRcsBlock/part.cfg
@@ -139,7 +139,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/Parts/Control/RetractablerRcsCurved/partCurved.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RetractablerRcsCurved/partCurved.cfg
@@ -60,7 +60,7 @@ PART
 				pitch = 1.0 1.0
 				loop = true
 			}
-			MODEL_MULTI_PARTICLE
+			MODEL_MULTI_PARTICLE:NEEDS[!Waterfall]
 			{
 				modelName = Squad/FX/Monoprop_medium
 				transformName = RCSthruster
@@ -116,5 +116,39 @@ PART
 		partMass = 0.1			// mass visible in the VAB 
 		maxIsp = 1000 			// Max powered Isp for Hydrogen
 		minIsp = 272  			// Max unpowered Isp for Hydrogen
+	}
+
+	MODULE:NEEDS[Waterfall]
+	{
+		name = ModuleWaterfallFX
+		// This is a custom name
+		moduleID = rcsFX
+		// This links the effects to a given ModuleEngines if desired. If not, it will use the basic one.
+		engineID = basicEngine
+
+		// List out all controllers we want available
+		// This controller scales with atmosphere depth
+		CONTROLLER
+		{
+			name = atmosphereDepth
+			linkedTo = atmosphere_density
+		}
+		// This controller scales with effective throttle
+		CONTROLLER
+		{
+			name = rcs
+			linkedTo = rcs
+		}
+
+		TEMPLATE
+		{
+			// This is the name of the template to use
+			templateName = waterfall-interstellar-rcs-resistojet-1
+			// This field allows you to override the parentTransform name in the EFFECTS contained in the template
+			overrideParentTransform = RCSthruster
+			position = 0,0,0
+			rotation = 0, 0, 180
+			scale = 0.5, 1, 0.5
+		}
 	}
 }

--- a/GameData/WarpPlugin/Parts/Control/RetractablerRcsCurved/partCurved.cfg
+++ b/GameData/WarpPlugin/Parts/Control/RetractablerRcsCurved/partCurved.cfg
@@ -139,7 +139,11 @@ PART
 			name = rcs
 			linkedTo = rcs
 		}
-
+		CONTROLLER
+		{
+			name = rcsPower
+			linkedTo = custom
+		}
 		TEMPLATE
 		{
 			// This is the name of the template to use

--- a/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-arcjet-1.cfg
+++ b/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-arcjet-1.cfg
@@ -1,0 +1,258 @@
+EFFECTTEMPLATE
+{
+	templateName = waterfall-interstellar-rcs-arcjet-1
+	EFFECT
+	{
+		name = arcjet
+		parentName = RCSThrust
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,-0.0500000007,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0199999996,0.699999988,0.0199999996
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 6.31943464
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 6.52165699
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 0.606665552
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 137.499786
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 2.52602816
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.00999999978
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.34117648,0.686274529,0.913725495,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -0.5
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0.00505554769
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightness
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expand
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 2 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = arcjet2
+		parentName = RCSThrust
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0399999991,2,0.0399999991
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,1,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 8.18998718
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 6.06665754
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 2.72999573
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 155.699753
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.955561697
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.358832777
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1.0055548
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightness
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 1.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expand
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 4 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+}

--- a/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-arcjet-1.cfg
+++ b/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-arcjet-1.cfg
@@ -3,12 +3,264 @@ EFFECTTEMPLATE
 	templateName = waterfall-interstellar-rcs-arcjet-1
 	EFFECT
 	{
+		name = rcs
+		parentName = RCSThrust
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0500000007,1.29999995,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,1,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 6.06665754
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.26082802
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 137.499786
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.00999999978
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightNess
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 5 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = arcjet_power
+			controllerName = rcsPower
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 1 0 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = rcs2
+		parentName = RCSThrust
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0500000007,1.29999995,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 4.65110397
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.26082826
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 128.399796
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.545000732
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1.01110959
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.783609867
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightNess
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 5 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = arcjet_power
+			controllerName = rcsPower
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 1 0 0
+				key = 1 0 0 0
+			}
+		}
+	}
+	EFFECT
+	{
 		name = arcjet
 		parentName = RCSThrust
 		MODEL
 		{
 			path = Waterfall/FX/fx-cylinder
-			positionOffset = 0,-0.0500000007,0
+			positionOffset = 0,0,0
 			rotationOffset = 0,0,0
 			scaleOffset = 0.0199999996,0.699999988,0.0199999996
 			MATERIAL
@@ -16,6 +268,23 @@ EFFECTTEMPLATE
 				transform = Cylinder
 				shader = Waterfall/Additive (Dynamic)
 				randomizeSeed = True
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-4
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 0.34117648,0.686274529,0.913725495,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
 				FLOAT
 				{
 					floatName = _Falloff
@@ -54,17 +323,7 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _FadeIn
-					value = 0.00999999978
-				}
-				COLOR
-				{
-					colorName = _StartTint
-					colorValue = 0.34117648,0.686274529,0.913725495,1
-				}
-				COLOR
-				{
-					colorName = _EndTint
-					colorValue = 1,1,1,1
+					value = 0.0500000007
 				}
 				FLOAT
 				{
@@ -81,22 +340,15 @@ EFFECTTEMPLATE
 					floatName = _ExpandSquare
 					value = 0
 				}
-				TEXTURE
-				{
-					textureSlotName = _MainTex
-					texturePath = Waterfall/FX/fx-noise-4
-					textureScale = 1,1
-					textureOffset = 0,0
-				}
 				FLOAT
 				{
 					floatName = _FalloffStart
-					value = 0.00505554769
+					value = 0.00499999989
 				}
 				FLOAT
 				{
 					floatName = _FadeOut
-					value = 0
+					value = 0.25
 				}
 			}
 		}
@@ -113,7 +365,7 @@ EFFECTTEMPLATE
 			floatCurve
 			{
 				key = 0 0 0 0
-				key = 1 5 0 0
+				key = 1 4 11 0
 			}
 		}
 		FLOATMODIFIER
@@ -129,6 +381,22 @@ EFFECTTEMPLATE
 			floatCurve
 			{
 				key = 0 2 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = arcjet_power
+			controllerName = rcsPower
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
 				key = 1 1 0 0
 			}
 		}
@@ -168,12 +436,12 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _Falloff
-					value = 8.18998718
+					value = 7.83609867
 				}
 				FLOAT
 				{
 					floatName = _Fresnel
-					value = 6.06665754
+					value = 6.16776848
 				}
 				FLOAT
 				{
@@ -183,7 +451,7 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _ExpandLinear
-					value = 1
+					value = 0
 				}
 				FLOAT
 				{
@@ -198,26 +466,31 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _Brightness
-					value = 0.955561697
+					value = 0.75
 				}
 				FLOAT
 				{
 					floatName = _FadeIn
-					value = 0.358832777
+					value = 0.0500000007
 				}
 				FLOAT
 				{
 					floatName = _ExpandOffset
-					value = -1.0055548
+					value = 0
 				}
 				FLOAT
 				{
 					floatName = _ExpandBounded
-					value = 5
+					value = 1
 				}
 				FLOAT
 				{
 					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
 					value = 0
 				}
 			}
@@ -235,7 +508,7 @@ EFFECTTEMPLATE
 			floatCurve
 			{
 				key = 0 0 0 0
-				key = 1 1.5 0 0
+				key = 1 0.75 0 0
 			}
 		}
 		FLOATMODIFIER
@@ -251,6 +524,22 @@ EFFECTTEMPLATE
 			floatCurve
 			{
 				key = 0 4 0 0
+				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = arcjet_power
+			controllerName = rcsPower
+			transformName = Cylinder
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
 				key = 1 1 0 0
 			}
 		}

--- a/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-resistojet-1.cfg
+++ b/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-resistojet-1.cfg
@@ -1,0 +1,363 @@
+EFFECTTEMPLATE
+{
+	templateName = waterfall-interstellar-rcs-resistojet-1
+	EFFECT
+	{
+		name = rcs
+		parentName = RCSthruster
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0500000007,1.29999995,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 6.06665754
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.26082802
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 137.499786
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.00999999978
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,1,1,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightNess
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = rcs2
+		parentName = RCSthruster
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0500000007,1.29999995,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 4.65110397
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 3.26082826
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1.71888626
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 128.399796
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 4
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0.545000732
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = -1.01110959
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0.783609867
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightNess
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 1 0.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandLinear
+			floatCurve
+			{
+				key = 0 5 0 0
+				key = 1 1 0 0
+			}
+		}
+	}
+	EFFECT
+	{
+		name = resjet
+		parentName = RCSthruster
+		MODEL
+		{
+			path = Waterfall/FX/fx-cylinder
+			positionOffset = 0,0,0
+			rotationOffset = 0,0,0
+			scaleOffset = 0.0500000007,0.400000006,0.0500000007
+			MATERIAL
+			{
+				transform = Cylinder
+				shader = Waterfall/Additive (Dynamic)
+				randomizeSeed = True
+				COLOR
+				{
+					colorName = _StartTint
+					colorValue = 1,0.801581502,0,1
+				}
+				COLOR
+				{
+					colorName = _EndTint
+					colorValue = 1,1,1,1
+				}
+				FLOAT
+				{
+					floatName = _Falloff
+					value = 5.66221333
+				}
+				FLOAT
+				{
+					floatName = _Fresnel
+					value = 6.01610184
+				}
+				FLOAT
+				{
+					floatName = _Noise
+					value = 1.0616647
+				}
+				FLOAT
+				{
+					floatName = _ExpandLinear
+					value = 1
+				}
+				FLOAT
+				{
+					floatName = _SpeedY
+					value = 160.566727
+				}
+				FLOAT
+				{
+					floatName = _TileX
+					value = 5
+				}
+				FLOAT
+				{
+					floatName = _Brightness
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FadeIn
+					value = 0.00999999978
+				}
+				FLOAT
+				{
+					floatName = _FadeOut
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FalloffStart
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _Seed
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _FresnelInvert
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _TintFalloff
+					value = 0
+				}
+				TEXTURE
+				{
+					textureSlotName = _MainTex
+					texturePath = Waterfall/FX/fx-noise-3
+					textureScale = 1,1
+					textureOffset = 0,0
+				}
+				FLOAT
+				{
+					floatName = _ExpandBounded
+					value = 0.5
+				}
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = brightNess
+			controllerName = rcs
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _Brightness
+			floatCurve
+			{
+				key = 0 0 0 0
+				key = 0.25 0 0.4 2
+				key = 0.5 1 4 4
+				key = 1 1.5 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 1.5 0 0
+				key = 1 0.5 0 0
+			}
+		}
+	}
+}

--- a/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-resistojet-heavy.cfg
+++ b/GameData/WarpPlugin/WaterfallFX/waterfall-interstellar-rcs-resistojet-heavy.cfg
@@ -1,6 +1,6 @@
 EFFECTTEMPLATE
 {
-	templateName = waterfall-interstellar-rcs-resistojet-1
+	templateName = waterfall-interstellar-rcs-resistojet-heavy
 	EFFECT
 	{
 		name = rcs
@@ -125,6 +125,45 @@ EFFECTTEMPLATE
 				key = 1 1 0 0
 			}
 		}
+		FLOATMODIFIER
+		{
+			name = powered
+			controllerName = rcsPower
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _SpeedY
+			floatCurve
+			{
+				key = 0 100 0 0
+				key = 1 200 0 0
+			}
+		}
+		SCALEMODIFIER
+		{
+			name = powered_length
+			controllerName = rcsPower
+			transformName = Waterfall/FX/fx-cylinder(Clone)
+			combinationType = MULTIPLY
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			xCurve
+			{
+				key = 0 1 0 0
+			}
+			yCurve
+			{
+				key = 0 1 0 0
+				key = 1 2 0 0
+			}
+			zCurve
+			{
+				key = 0 1 0 0
+			}
+		}
 	}
 	EFFECT
 	{
@@ -228,9 +267,9 @@ EFFECTTEMPLATE
 		MODEL
 		{
 			path = Waterfall/FX/fx-cylinder
-			positionOffset = 0,0,0
+			positionOffset = 0,0.02,0
 			rotationOffset = 0,0,0
-			scaleOffset = 0.0500000007,0.400000006,0.0500000007
+			scaleOffset = 0.0199999996,0.400000006,0.0199999996
 			MATERIAL
 			{
 				transform = Cylinder
@@ -271,7 +310,7 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _ExpandLinear
-					value = 1
+					value = 0
 				}
 				FLOAT
 				{
@@ -291,7 +330,7 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _FadeIn
-					value = 0.00999999978
+					value = 0.0500000007
 				}
 				FLOAT
 				{
@@ -321,7 +360,17 @@ EFFECTTEMPLATE
 				FLOAT
 				{
 					floatName = _ExpandBounded
-					value = 0.5
+					value = 2
+				}
+				FLOAT
+				{
+					floatName = _ExpandSquare
+					value = 0
+				}
+				FLOAT
+				{
+					floatName = _ExpandOffset
+					value = 0
 				}
 			}
 		}
@@ -338,25 +387,8 @@ EFFECTTEMPLATE
 			floatCurve
 			{
 				key = 0 0 0 0
-				key = 0.25 0 0.4 2
-				key = 0.5 1 4 4
-				key = 1 1.5 0 0
-			}
-		}
-		FLOATMODIFIER
-		{
-			name = expando
-			controllerName = atmosphereDepth
-			transformName = Cylinder
-			combinationType = REPLACE
-			useRandomness = False
-			randomnessController = random
-			randomnessScale = 1
-			floatName = _ExpandBounded
-			floatCurve
-			{
-				key = 0 1.5 0 0
-				key = 1 0.5 0 0
+				key = 0.5 1.5 8 4
+				key = 1 2 0 0
 			}
 		}
 		FLOATMODIFIER
@@ -373,6 +405,22 @@ EFFECTTEMPLATE
 			{
 				key = 0 0 0 0
 				key = 1 1 0 0
+			}
+		}
+		FLOATMODIFIER
+		{
+			name = expando
+			controllerName = atmosphereDepth
+			transformName = Cylinder
+			combinationType = REPLACE
+			useRandomness = False
+			randomnessController = random
+			randomnessScale = 1
+			floatName = _ExpandBounded
+			floatCurve
+			{
+				key = 0 3.5 0 0
+				key = 1 2 0 0
 			}
 		}
 	}


### PR DESCRIPTION
This adds support for Waterfall integration with custom controllers so that Waterfall effects can be controlled programmatically, and uses this support to add Waterfall effects to RCS arcjets/resistojets that respond to whether the thruster is powered or not.  The Waterfall support can be extended to support other kinds of custom controllers rather easily.

As part of this, Waterfall will be required as a reference and build dependency for WarpPlugin.  Since a copy of Waterfall is already included in the repository, I used that copy as my reference.  However, all references to Waterfall are contained within their own class, and as long as no functions from that class are called without first verifying that Waterfall is loaded (for example by evaluating `part.Modules.Contains("ModuleWaterfallFX")`), it will not attempt to load Waterfall.dll, so Waterfall won't be a dependency for end users.  If it is called when Waterfall isn't loaded and without testing for that, a `FileNotFoundException` will be thrown, the game will continue running, but I haven't tested if this results in any ill effects beyond an exceptionally large log file.

This has been tested to ensure RCS effects work, respond properly to power state, and that it safely falls back to default if Waterfall is not installed.  A few RCS parts have their thrusters misaligned in ways that I believe can't be corrected without altering the model -- 5-way Resistojet RCS Block, Omnidirectional Vernier RCS Thruster System, and Inline Arcjet RCS Fuel Tank SM-500 all have one or more thrusters at incorrect angles.