### PR TITLE
Fix and upgrade Reactor Control Window in VAB/SPH

### DIFF
--- a/FNPlugin/Reactors/InterstellarInertialConfinementReactor.cs
+++ b/FNPlugin/Reactors/InterstellarInertialConfinementReactor.cs
@@ -467,5 +467,11 @@ namespace FNPlugin.Reactors
                 accumulatedElectricChargeInMW += secondaryPowerReceived / secondaryInputMultiplier;
             }
         }
+
+        public override void UpdateEditorPowerOutput()
+        {
+            base.UpdateEditorPowerOutput();
+            electricPowerMaintenance = PluginHelper.GetFormattedPowerString(LaserPowerRequirements) + " / " + PluginHelper.GetFormattedPowerString(LaserPowerRequirements);
+        }
     }
 }

--- a/FNPlugin/Reactors/InterstellarReactor.cs
+++ b/FNPlugin/Reactors/InterstellarReactor.cs
@@ -1086,6 +1086,13 @@ namespace FNPlugin.Reactors
             if (minimumThrottleMk7 <= 0) minimumThrottleMk7 = minimumThrottleMk6;
         }
 
+        public virtual void UpdateEditorPowerOutput()
+        {
+            ongoing_thermal_power_generated = MaximumThermalPower;
+            ongoing_charged_power_generated = MaximumChargedPower;
+            ongoing_total_power_generated = ongoing_thermal_power_generated + ongoing_charged_power_generated;
+        }
+
         public override void OnStart(StartState state)
         {
             hasStarted = true;
@@ -1503,6 +1510,7 @@ namespace FNPlugin.Reactors
             {
                 DeterminePowerOutput();
                 maximumThermalPowerEffective = MaximumThermalPower;
+                UpdateEditorPowerOutput();
                 return;
             }
 
@@ -2670,7 +2678,7 @@ namespace FNPlugin.Reactors
 
             WindowReactorStatusSpecificOverride();
 
-            PrintToGuiLayout("Lifetime", ConvertSecondsToDayHourMinute((int)Math.Max(Planetarium.GetUniversalTime() - startTime, vessel.missionTime)), boldStyle, textStyle);
+            PrintToGuiLayout("Lifetime", ConvertSecondsToDayHourMinute((int)Math.Max(Planetarium.GetUniversalTime() - startTime, vessel == null ? 0d : vessel.missionTime)), boldStyle, textStyle);
 
             PrintToGuiLayout(Localizer.Format("#LOC_KSPIE_Reactor_Radius"), radius + "m", boldStyle, textStyle);//"Radius"
             PrintToGuiLayout(Localizer.Format("#LOC_KSPIE_Reactor_CoreTemperature"), coretempStr, boldStyle, textStyle);//"Core Temperature"

--- a/FNPlugin/Reactors/InterstellarTokomakFusionReator.cs
+++ b/FNPlugin/Reactors/InterstellarTokomakFusionReator.cs
@@ -196,5 +196,12 @@ namespace FNPlugin.Reactors
 
             base.OnStart(state);
         }
+
+        public override void UpdateEditorPowerOutput()
+        {
+            base.UpdateEditorPowerOutput();
+            required_reactor_ratio = 1.0;
+            electricPowerMaintenance = PluginHelper.GetFormattedPowerString(HeatingPowerRequirements) + " / " + PluginHelper.GetFormattedPowerString(HeatingPowerRequirements);
+        }
     }
 }


### PR DESCRIPTION
Fixed a null pointer exception in the reactor control window.

While I was at it, I also upgraded the window to display most values as if working at max power. The window now displays, fuel usage and fuel lifetimes as well as fusion maintainance cost for fusion reactors.