### PR TITLE
Fix Magnetohydrodynamic Electric Generator not using MHD mode

### DIFF
--- a/FNPlugin/Powermanagement/FNGenerator.cs
+++ b/FNPlugin/Powermanagement/FNGenerator.cs
@@ -766,7 +766,7 @@ namespace FNPlugin.Powermanagement
                 : _attachedPowerSource.HotBathTemperature + Math.Pow(coreTemperature - _attachedPowerSource.HotBathTemperature, coreTemperateHotBathExponent);
 
             double temperature;
-            if (_appliesBalance || !isMHD)
+            if (!isMHD)
                 temperature = _attachedPowerSource.HotBathTemperature;
             else
             {
@@ -955,7 +955,7 @@ namespace FNPlugin.Powermanagement
         {
             if (IsEnabled && _attachedPowerSource != null && FNRadiator.HasRadiatorsForVessel(vessel))
             {
-                _appliesBalance = isMHD || _attachedPowerSource.ShouldApplyBalance(chargedParticleMode ? ElectricGeneratorType.charged_particle : ElectricGeneratorType.thermal);
+                _appliesBalance = _attachedPowerSource.ShouldApplyBalance(chargedParticleMode ? ElectricGeneratorType.charged_particle : ElectricGeneratorType.thermal);
 
                 UpdateGeneratorPower();
 


### PR DESCRIPTION
### Issue
Right now the MHD generator does not work properly. This is caused by one or two lines in FNGenerator.cs

When calculating the hot bath temperature the following condition is evaluated: 

```
if (_appliesBalance || !isMHD)
```

[FNGenerator.cs#L769](https://github.com/sswelm/KSP-Interstellar-Extended/blob/3bd0e62a97b273d19b4f2db06804f2d40899eed7/FNPlugin/Powermanagement/FNGenerator.cs#L769).

And `_appliesBalance` is set by

```
_appliesBalance = isMHD || _attachedPowerSource.ShouldApplyBalance(chargedParticleMode ? ElectricGeneratorType.charged_particle : ElectricGeneratorType.thermal);
```
[FNGenerator.cs#L958](https://github.com/sswelm/KSP-Interstellar-Extended/blob/3bd0e62a97b273d19b4f2db06804f2d40899eed7/FNPlugin/Powermanagement/FNGenerator.cs#L958)

Which means the first condition **always evaluates as true**. The MHD generator always uses the hot bath temperature of the power source, turning it into a worse version of the thermal generator.

### Fix

If I understand it correctly, `_appliesBalance` is used when a nozzle and a generator are attached to the same reactor.

- `_appliesBalance` should not factor into the calculation of the hot bath temperature.
- There is no need for a MHD generator to use balancing all by itself, hence the `isMHD` was removed from the assignment of `_appliesBalance`

---

The code using `_appliesBalance` was commented out in many places. All it does is influence the megajoules buffer of the generator. When using a charged particle only mode such as Lithium6 cycle fusion, the buffer drops to zero. This seems rather odd, but it's another issue.