### PR TITLE
Add Uranium-233 to ISRU and Remove Uranium from Thorium fuel

### DIFF
--- a/GameData/WarpPlugin/Localization/Parts/en-us.cfg
+++ b/GameData/WarpPlugin/Localization/Parts/en-us.cfg
@@ -208,6 +208,10 @@
 		#LOC_KSPIE_StartActionName17 = Start Silicates Processing
 		#LOC_KSPIE_StopActionName17 = Stop Silicates Processing
 
+		#LOC_KSPIE_ConverterName18 = Uranium-233 manufacturer
+		#LOC_KSPIE_StartActionName18 = Start Uranium-233 production
+		#LOC_KSPIE_StopActionName18 = Stop Uranium-233 production
+
 		#LOC_KSPIE_ElectricRCSController_displayName1 = Linear Arcjet RCS	// (Optional) shows Name visible in Power management
 		#LOC_KSPIE_ElectricRCSController_displayName2 = Inline Arcjet RCS	// (Optional) shows Name visible in Power management
 		#LOC_KSPIE_ElectricRCSController_displayName3 = Arcjet RCS	// (Optional) shows Name visible in Power management

--- a/GameData/WarpPlugin/Parts/Utility/HexAssembly/HaberBosch.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/HexAssembly/HaberBosch.cfg
@@ -126,6 +126,44 @@ NODE
 		}
 	}
 
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = #LOC_KSPIE_ConverterName18 // #LOC_KSPIE_ConverterName18 = Uranium-233 manufacturer
+		StartActionName = #LOC_KSPIE_StartActionName18 // #LOC_KSPIE_StartActionName18 = Start Uranium-233 production
+		StopActionName = #LOC_KSPIE_StopActionName18 // #LOC_KSPIE_StopActionName18 = Stop Uranium-233 production
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 1
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdFluorine
+			Ratio = 1.789  //  (19*4)/(232+(19*4)) * (10.97/1.505)
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 32
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 943	// (16*2)/(232+(16*2)) * (10.97/0.00141)
+			DumpExcess = True
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Uranium-233
+			Ratio = 1.25	// 232/(232+(18*4)) * 10.97/6.70
+			DumpExcess = False
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+	}
+
 
 	MODULE
 	{

--- a/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/ISRU/ISRU.cfg
@@ -822,6 +822,44 @@ PART
 		}
 	}
 
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = #LOC_KSPIE_ConverterName18 // #LOC_KSPIE_ConverterName18 = Uranium-233 manufacturer
+		StartActionName = #LOC_KSPIE_StartActionName18 // #LOC_KSPIE_StartActionName18 = Start Uranium-233 production
+		StopActionName = #LOC_KSPIE_StopActionName18 // #LOC_KSPIE_StopActionName18 = Stop Uranium-233 production
+
+		INPUT_RESOURCE
+		{
+			ResourceName = EnrichedUranium
+			Ratio = 1
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = LqdFluorine
+			Ratio = 1.789  //  (19*4)/(232+(19*4)) * (10.97/1.505)
+		}
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 32
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Oxygen
+			Ratio = 943	// (16*2)/(232+(16*2)) * (10.97/0.00141)
+			DumpExcess = True
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = Uranium-233
+			Ratio = 1.25	// 232/(232+(18*4)) * 10.97/6.70
+			DumpExcess = False
+			FlowMode = STAGE_PRIORITY_FLOW
+		}
+	}
+
 
 	MODULE
 	{

--- a/GameData/WarpPlugin/Resources/ReactorFuels.cfg
+++ b/GameData/WarpPlugin/Resources/ReactorFuels.cfg
@@ -421,14 +421,6 @@ REACTOR_FUEL_MODE
 		Unit = kg
 		consumeGlobal = False
 	}
-	FUEL
-	{
-		name = Uranium
-		resource = Uranium-233
-		UsagePerMW = 1.5e-11
-		Unit = kg
-		consumeGlobal = False
-	}
 
    	PRODUCT
 	{
@@ -454,13 +446,6 @@ REACTOR_FUEL_MODE
    	PRODUCT
 	{
 		name = Actinides
-		ProductionPerMW = 1.5e-11
-		Unit = kg
-		produceGlobal = False
-	}
-	PRODUCT
-	{
-		name = Protactinium-233
 		ProductionPerMW = 1.5e-11
 		Unit = kg
 		produceGlobal = False
@@ -624,13 +609,6 @@ REACTOR_FUEL_MODE
 		Unit = kg
 		produceGlobal = False
 	}
-	PRODUCT
-	{
-		name = Protactinium-233
-		ProductionPerMW = 3.0e-11
-		Unit = kg
-		produceGlobal = False
-	}
 }
 
 REACTOR_FUEL_MODE
@@ -705,13 +683,6 @@ REACTOR_FUEL_MODE
 		Unit = kg
 		produceGlobal = False
 	}
-	PRODUCT
-	{
-		name = Protactinium-233
-		ProductionPerMW = 3.0e-11
-		Unit = kg
-		produceGlobal = False
-	}
 }
 
 REACTOR_FUEL_MODE
@@ -783,13 +754,6 @@ REACTOR_FUEL_MODE
 	{
 		name = Actinides
 		ProductionPerMW = 1.5e-11
-		Unit = kg
-		produceGlobal = False
-	}
-	PRODUCT
-	{
-		name = Protactinium-233
-		ProductionPerMW = 3.0e-11
 		Unit = kg
 		produceGlobal = False
 	}

--- a/GameData/WarpPlugin/Resources/ReactorFuels.cfg
+++ b/GameData/WarpPlugin/Resources/ReactorFuels.cfg
@@ -349,14 +349,6 @@ REACTOR_FUEL_MODE
 		Unit = kg
 		consumeGlobal = False
 	}
-	FUEL
-	{
-		name = Uranium
-		resource = Uranium-233
-		UsagePerMW = 1.5e-11
-		Unit = kg
-		consumeGlobal = False
-	}
 
    	PRODUCT
 	{
@@ -446,6 +438,13 @@ REACTOR_FUEL_MODE
    	PRODUCT
 	{
 		name = Actinides
+		ProductionPerMW = 1.5e-11
+		Unit = kg
+		produceGlobal = False
+	}
+	PRODUCT
+	{
+		name = Protactinium-233
 		ProductionPerMW = 1.5e-11
 		Unit = kg
 		produceGlobal = False


### PR DESCRIPTION
In a game where ISRU is used completely to setup the resource chain, it is impossible to attain Uranium-233 by any means. Trust me, I've just wasted 4 nights trying.

The alternatives, again, Thorium... doesn't even work because once again, it's a hidden requirement to have Uranium-233....

This PR sets things right.

1. Uranium-233 has been added to ISRU
2. Thorium is the only fuel required when MSR says "Thorium".
3. Left Uranium for breeding activities.

I don't know about nuclear reactors, but I do know when a game breaks. And this was broken for far too long.

Thanks.