### PR TITLE
Fix FNImpactorModule event-subscription leak (#744)

### DIFF
--- a/FNPlugin/Science/FNImpactorModule.cs
+++ b/FNPlugin/Science/FNImpactorModule.cs
@@ -19,6 +19,17 @@ namespace FNPlugin.Science
             Debug.Log("[KSPI]: FNImpactorModule listening for collisions.");
         }
 
+        public void OnDestroy()
+        {
+            // Mirror Awake(): without these Remove calls, every scene change
+            // leaks an additional delegate reference into the static
+            // GameEvents.onCollision / onCrash lists. After enough scene
+            // transitions the heap is large enough to trip Mono's GC
+            // ("Unexpected mark stack overflow") and crash the game.
+            GameEvents.onCollision.Remove(OnVesselAboutToBeDestroyed);
+            GameEvents.onCrash.Remove(OnVesselAboutToBeDestroyed);
+        }
+
         public void OnVesselAboutToBeDestroyed(EventReport report)
         {
             Debug.Log("[KSPI]: Handling Impactor");


### PR DESCRIPTION
## Summary

Fixes #744.

`FNPlugin/Science/FNImpactorModule.cs` subscribes `OnVesselAboutToBeDestroyed` to `GameEvents.onCollision` and `GameEvents.onCrash` in `Awake()` but has no `OnDestroy()` to remove them. Because `GameEvents` are static singletons, every scene transition (VAB → flight, flight → space center, recovery, revert, etc.) instantiates a fresh `FNImpactorModule` and adds another delegate reference to those static event lists. The previous instances are destroyed but their delegates remain rooted via the static reference, so neither the delegate nor the captured `MonoBehaviour` is ever GC'd.

After a few hours of play the leaked delegate graph is large enough that Mono's GC mark phase overflows its stack:

```
Fatal error in GC: Unexpected mark stack overflow
```

…and the game crashes. The crash is reproducible on any save with KSPIE installed given enough scene transitions.

## Fix

Add `OnDestroy()` that mirrors `Awake()`:

```csharp
public void OnDestroy()
{
    GameEvents.onCollision.Remove(OnVesselAboutToBeDestroyed);
    GameEvents.onCrash.Remove(OnVesselAboutToBeDestroyed);
}
```

`GameEvents.Remove` is the standard inverse of `Add` and is safe even if the handler was never registered (no-op).

## Verification

Tested locally on KSP 1.12.5 with KSPIE installed. With an external Harmony patch implementing the equivalent cleanup ([KSPIE_LeakFix](https://github.com/edujoliver/KSPIE-LeakFix)), the previously reliable mark-stack-overflow crash no longer occurs across extended sessions with many scene transitions. This PR applies the same fix in-tree so the external patch is no longer needed.

## Notes

Diff is +11 lines (10 of which are a comment explaining why). No behavior change beyond proper cleanup on destruction.