### PR TITLE
Fix Minmus body-name typo (Minimus -> Minmus) in resource configs

### DIFF
--- a/GameData/WarpPlugin/ResourceConfigs/Alumina.cfg
+++ b/GameData/WarpPlugin/ResourceConfigs/Alumina.cfg
@@ -297,7 +297,7 @@ PLANETARY_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	Tag = Spared
 	
 	Distribution
@@ -310,12 +310,12 @@ PLANETARY_RESOURCE
 	}
 }
 
-// Highlands on Minimus always have Alumina
+// Highlands on Minmus always have Alumina
 BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Highlands
 	Tag = Spared
 	
@@ -329,12 +329,12 @@ BIOME_RESOURCE
 	}
 }
 
-// Flats on Minimus have no Alumina
+// Flats on Minmus have no Alumina
 BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Flats
 	Tag = Spared
 	
@@ -351,7 +351,7 @@ BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Lesser Flats
 	Tag = Spared
 	
@@ -368,7 +368,7 @@ BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Great Flats
 	Tag = Spared
 	
@@ -385,7 +385,7 @@ BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Greater Flats
 	Tag = Spared
 	
@@ -402,7 +402,7 @@ BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Basins
 	Tag = Spared
 	
@@ -419,7 +419,7 @@ BIOME_RESOURCE
 {
 	ResourceName = Alumina
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName = Brown Basins
 	Tag = Spared
 	

--- a/GameData/WarpPlugin/ResourceConfigs/Hydrates.cfg
+++ b/GameData/WarpPlugin/ResourceConfigs/Hydrates.cfg
@@ -106,7 +106,7 @@ BIOME_RESOURCE
 	}
 }
 
-// At Minimus Hydrates are highly concentrated at on the salt lakes and poles
+// At Minmus Hydrates are highly concentrated at on the salt lakes and poles
  
 PLANETARY_RESOURCE
 {

--- a/GameData/WarpPlugin/ResourceConfigs/Spodumene.cfg
+++ b/GameData/WarpPlugin/ResourceConfigs/Spodumene.cfg
@@ -44,12 +44,12 @@ PLANETARY_RESOURCE
 	}
 }
 
-// Minimus has rich in nitrogen
+// Minmus has rich in nitrogen
 PLANETARY_RESOURCE
 {
 	ResourceName = Spodumene
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	Tag = Spared
 	
 	Distribution
@@ -62,12 +62,12 @@ PLANETARY_RESOURCE
 	}
 }
 
-// Minimus flats
+// Minmus flats
 BIOME_RESOURCE
 {
 	ResourceName = Spodumene
 	ResourceType = 0
-	PlanetName = Minimus
+	PlanetName = Minmus
 	BiomeName =  Flats
 	Tag = Spared
 	


### PR DESCRIPTION
## Problem

The CRP resource distributions for **Alumina** and **Spodumene** target a body named `Minimus`, but the moon is `Minmus` (no second "i"). `Minimus` is not a valid body, so these `PLANETARY_RESOURCE` / `BIOME_RESOURCE` blocks never match anything — the intended distributions **silently never apply on Minmus**, and those resources fall back to their `GLOBAL_RESOURCE` roll only.

This is easy to miss because there is no load error; the blocks just do nothing.

## Affected blocks

- `GameData/WarpPlugin/ResourceConfigs/Alumina.cfg` — **8** blocks (planetary + Highlands/Flats biome tuning)
- `GameData/WarpPlugin/ResourceConfigs/Spodumene.cfg` — **2** blocks (planetary 100% + Flats 200%)

`Hydrates.cfg` already uses the correct `Minmus` in its functional blocks; only a stale comment is corrected there.

## Change

Pure typo fix: `Minimus` → `Minmus`. Ten functional `PlanetName` fields now resolve to the real body; same-typo comments are corrected for consistency. **No distribution values (PresenceChance/MinAbundance/MaxAbundance/Variance/Dispersal) are changed.**

## Testing

- Confirmed `Minimus` is not defined as a body in stock/Kopernicus/OPM.
- `grep` confirms no `Minimus` remains after the change; diff is limited to the 15 typo lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
