### PR TITLE
Fix UraniumNitride tank: lowercase resource name in Hex Radioactive Container

### DIFF
--- a/GameData/WarpPlugin/Parts/Utility/HexAssembly/radioactive.cfg
+++ b/GameData/WarpPlugin/Parts/Utility/HexAssembly/radioactive.cfg
@@ -81,8 +81,8 @@ PART
 	{
 		name = InterstellarFuelSwitch
 		tankSwitchNames = Actinides;Depleted Fuel;Uraninite;Depleted Uranium;Enriched Uranium;Fission Particles;Fission Pellets;Fission Products;Plutonium 239;Protactin 233;Thorium;Uranium 233;Uranium Nitride;UF4;ThF4
-		resourceGui =   Actinides;DepletedFuel;Uraninite;DepletedUranium;EnrichedUranium;FissionParticles;FissionPellets;FissionProducts;Plutonium-239;Protactinium-233;Thorium;Uranium-233;uraniumnitride;UF4;ThF4
-		resourceNames = Actinides;DepletedFuel;Uraninite;DepletedUranium;EnrichedUranium;FissionParticles;FissionPellets;FissionProducts;Plutonium-239;Protactinium-233,Uranium-233;Thorium;Uranium-233;uraniumnitride;UF4;ThF4
+		resourceGui =   Actinides;DepletedFuel;Uraninite;DepletedUranium;EnrichedUranium;FissionParticles;FissionPellets;FissionProducts;Plutonium-239;Protactinium-233;Thorium;Uranium-233;UraniumNitride;UF4;ThF4
+		resourceNames = Actinides;DepletedFuel;Uraninite;DepletedUranium;EnrichedUranium;FissionParticles;FissionPellets;FissionProducts;Plutonium-239;Protactinium-233,Uranium-233;Thorium;Uranium-233;UraniumNitride;UF4;ThF4
 		resourceAmounts = 750;750;750;750;750;750;750;750;750;750,1e-10;750;750;750;750;750
 		initialResourceAmounts =   0;  0;  750; 0;750;750;750;750;750;  0,    0;750;750;750;750;750
 		basePartMass = 0.3


### PR DESCRIPTION
## Problem
The **Hex Segment Radioactive Container** (`KSPI_Hex_Radioactive_Container`, in `GameData/WarpPlugin/Parts/Utility/HexAssembly/radioactive.cfg`) declares its **Uranium Nitride** tank with the resource name in lowercase — `uraniumnitride` — in both `resourceNames` and `resourceGui` (slot 13).

KSP resource names are **case-sensitive**, and the real resource is `UraniumNitride` (`FNPlugin/Resources/ResourceSettings.cs`: `public string UraniumNitride { get; private set; } = "UraniumNitride";`). So selecting the *Uranium Nitride* tank setup creates an **undefined** resource: the tank gets no capacity, doesn't pool with the vessel's `UraniumNitride`, and can't store or feed reactor fuel. In-game the tank shows `Tank name: uraniumnitride` and holds nothing, so Pebble Bed reactor fuel can't be buffered in this container.

## Fix
Correct slot 13 in both `resourceNames` and `resourceGui` from `uraniumnitride` → `UraniumNitride`. No other slots change, including the intentional dual-resource `Protactinium-233,Uranium-233` decay tank in `resourceNames` slot 10.

## Result
Switching the container to the Uranium Nitride tank now allocates real `UraniumNitride` capacity that pools with — and can fuel — Pebble Bed reactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
